### PR TITLE
Make creation of things and actions syncronous

### DIFF
--- a/client/actions/actions_client.go
+++ b/client/actions/actions_client.go
@@ -91,7 +91,7 @@ WeaviateActionsCreate creates actions between two things object and subject
 
 Registers a new action. Given meta-data and schema values are validated.
 */
-func (a *Client) WeaviateActionsCreate(params *WeaviateActionsCreateParams, authInfo runtime.ClientAuthInfoWriter) (*WeaviateActionsCreateAccepted, error) {
+func (a *Client) WeaviateActionsCreate(params *WeaviateActionsCreateParams, authInfo runtime.ClientAuthInfoWriter) (*WeaviateActionsCreateOK, *WeaviateActionsCreateAccepted, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewWeaviateActionsCreateParams()
@@ -111,9 +111,15 @@ func (a *Client) WeaviateActionsCreate(params *WeaviateActionsCreateParams, auth
 		Client:             params.HTTPClient,
 	})
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return result.(*WeaviateActionsCreateAccepted), nil
+	switch value := result.(type) {
+	case *WeaviateActionsCreateOK:
+		return value, nil, nil
+	case *WeaviateActionsCreateAccepted:
+		return nil, value, nil
+	}
+	return nil, nil, nil
 
 }
 

--- a/client/actions/weaviate_action_update_responses.go
+++ b/client/actions/weaviate_action_update_responses.go
@@ -60,13 +60,6 @@ func (o *WeaviateActionUpdateReader) ReadResponse(response runtime.ClientRespons
 		}
 		return nil, result
 
-	case 501:
-		result := NewWeaviateActionUpdateNotImplemented()
-		if err := result.readResponse(response, consumer, o.formats); err != nil {
-			return nil, err
-		}
-		return nil, result
-
 	default:
 		return nil, runtime.NewAPIError("unknown error", response, response.Code())
 	}
@@ -189,27 +182,6 @@ func (o *WeaviateActionUpdateUnprocessableEntity) readResponse(response runtime.
 	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
 		return err
 	}
-
-	return nil
-}
-
-// NewWeaviateActionUpdateNotImplemented creates a WeaviateActionUpdateNotImplemented with default headers values
-func NewWeaviateActionUpdateNotImplemented() *WeaviateActionUpdateNotImplemented {
-	return &WeaviateActionUpdateNotImplemented{}
-}
-
-/*WeaviateActionUpdateNotImplemented handles this case with default header values.
-
-Not (yet) implemented.
-*/
-type WeaviateActionUpdateNotImplemented struct {
-}
-
-func (o *WeaviateActionUpdateNotImplemented) Error() string {
-	return fmt.Sprintf("[PUT /actions/{actionId}][%d] weaviateActionUpdateNotImplemented ", 501)
-}
-
-func (o *WeaviateActionUpdateNotImplemented) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	return nil
 }

--- a/client/actions/weaviate_actions_create_parameters.go
+++ b/client/actions/weaviate_actions_create_parameters.go
@@ -16,8 +16,6 @@ import (
 	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
-
-	models "github.com/creativesoftwarefdn/weaviate/models"
 )
 
 // NewWeaviateActionsCreateParams creates a new WeaviateActionsCreateParams object
@@ -65,7 +63,7 @@ for the weaviate actions create operation typically these are written to a http.
 type WeaviateActionsCreateParams struct {
 
 	/*Body*/
-	Body *models.ActionCreate
+	Body WeaviateActionsCreateBody
 
 	timeout    time.Duration
 	Context    context.Context
@@ -106,13 +104,13 @@ func (o *WeaviateActionsCreateParams) SetHTTPClient(client *http.Client) {
 }
 
 // WithBody adds the body to the weaviate actions create params
-func (o *WeaviateActionsCreateParams) WithBody(body *models.ActionCreate) *WeaviateActionsCreateParams {
+func (o *WeaviateActionsCreateParams) WithBody(body WeaviateActionsCreateBody) *WeaviateActionsCreateParams {
 	o.SetBody(body)
 	return o
 }
 
 // SetBody adds the body to the weaviate actions create params
-func (o *WeaviateActionsCreateParams) SetBody(body *models.ActionCreate) {
+func (o *WeaviateActionsCreateParams) SetBody(body WeaviateActionsCreateBody) {
 	o.Body = body
 }
 
@@ -124,10 +122,8 @@ func (o *WeaviateActionsCreateParams) WriteToRequest(r runtime.ClientRequest, re
 	}
 	var res []error
 
-	if o.Body != nil {
-		if err := r.SetBodyParam(o.Body); err != nil {
-			return err
-		}
+	if err := r.SetBodyParam(o.Body); err != nil {
+		return err
 	}
 
 	if len(res) > 0 {

--- a/client/actions/weaviate_actions_create_responses.go
+++ b/client/actions/weaviate_actions_create_responses.go
@@ -9,7 +9,9 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	"github.com/go-openapi/swag"
 
 	strfmt "github.com/go-openapi/strfmt"
 
@@ -24,6 +26,13 @@ type WeaviateActionsCreateReader struct {
 // ReadResponse reads a server response into the received o.
 func (o *WeaviateActionsCreateReader) ReadResponse(response runtime.ClientResponse, consumer runtime.Consumer) (interface{}, error) {
 	switch response.Code() {
+
+	case 200:
+		result := NewWeaviateActionsCreateOK()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return result, nil
 
 	case 202:
 		result := NewWeaviateActionsCreateAccepted()
@@ -53,16 +62,38 @@ func (o *WeaviateActionsCreateReader) ReadResponse(response runtime.ClientRespon
 		}
 		return nil, result
 
-	case 501:
-		result := NewWeaviateActionsCreateNotImplemented()
-		if err := result.readResponse(response, consumer, o.formats); err != nil {
-			return nil, err
-		}
-		return nil, result
-
 	default:
 		return nil, runtime.NewAPIError("unknown error", response, response.Code())
 	}
+}
+
+// NewWeaviateActionsCreateOK creates a WeaviateActionsCreateOK with default headers values
+func NewWeaviateActionsCreateOK() *WeaviateActionsCreateOK {
+	return &WeaviateActionsCreateOK{}
+}
+
+/*WeaviateActionsCreateOK handles this case with default header values.
+
+Action created
+*/
+type WeaviateActionsCreateOK struct {
+	Payload *models.ActionGetResponse
+}
+
+func (o *WeaviateActionsCreateOK) Error() string {
+	return fmt.Sprintf("[POST /actions][%d] weaviateActionsCreateOK  %+v", 200, o.Payload)
+}
+
+func (o *WeaviateActionsCreateOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(models.ActionGetResponse)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
 }
 
 // NewWeaviateActionsCreateAccepted creates a WeaviateActionsCreateAccepted with default headers values
@@ -72,7 +103,7 @@ func NewWeaviateActionsCreateAccepted() *WeaviateActionsCreateAccepted {
 
 /*WeaviateActionsCreateAccepted handles this case with default header values.
 
-Successfully received.
+Successfully received. No guarantees are made that the Action is persisted.
 */
 type WeaviateActionsCreateAccepted struct {
 	Payload *models.ActionGetResponse
@@ -165,23 +196,64 @@ func (o *WeaviateActionsCreateUnprocessableEntity) readResponse(response runtime
 	return nil
 }
 
-// NewWeaviateActionsCreateNotImplemented creates a WeaviateActionsCreateNotImplemented with default headers values
-func NewWeaviateActionsCreateNotImplemented() *WeaviateActionsCreateNotImplemented {
-	return &WeaviateActionsCreateNotImplemented{}
-}
-
-/*WeaviateActionsCreateNotImplemented handles this case with default header values.
-
-Not (yet) implemented.
+/*WeaviateActionsCreateBody weaviate actions create body
+swagger:model WeaviateActionsCreateBody
 */
-type WeaviateActionsCreateNotImplemented struct {
+type WeaviateActionsCreateBody struct {
+
+	// action
+	Action *models.ActionCreate `json:"action,omitempty"`
+
+	// If `async` is true, return a 202 with the new ID of the Action. You will receive this response before the data is persisted. If `async` is false, you will receive confirmation after the value is persisted. The value of `async` defaults to false.
+	Async bool `json:"async,omitempty"`
 }
 
-func (o *WeaviateActionsCreateNotImplemented) Error() string {
-	return fmt.Sprintf("[POST /actions][%d] weaviateActionsCreateNotImplemented ", 501)
+// Validate validates this weaviate actions create body
+func (o *WeaviateActionsCreateBody) Validate(formats strfmt.Registry) error {
+	var res []error
+
+	if err := o.validateAction(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
 }
 
-func (o *WeaviateActionsCreateNotImplemented) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+func (o *WeaviateActionsCreateBody) validateAction(formats strfmt.Registry) error {
 
+	if swag.IsZero(o.Action) { // not required
+		return nil
+	}
+
+	if o.Action != nil {
+		if err := o.Action.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("body" + "." + "action")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+// MarshalBinary interface implementation
+func (o *WeaviateActionsCreateBody) MarshalBinary() ([]byte, error) {
+	if o == nil {
+		return nil, nil
+	}
+	return swag.WriteJSON(o)
+}
+
+// UnmarshalBinary interface implementation
+func (o *WeaviateActionsCreateBody) UnmarshalBinary(b []byte) error {
+	var res WeaviateActionsCreateBody
+	if err := swag.ReadJSON(b, &res); err != nil {
+		return err
+	}
+	*o = res
 	return nil
 }

--- a/client/actions/weaviate_actions_delete_responses.go
+++ b/client/actions/weaviate_actions_delete_responses.go
@@ -50,13 +50,6 @@ func (o *WeaviateActionsDeleteReader) ReadResponse(response runtime.ClientRespon
 		}
 		return nil, result
 
-	case 501:
-		result := NewWeaviateActionsDeleteNotImplemented()
-		if err := result.readResponse(response, consumer, o.formats); err != nil {
-			return nil, err
-		}
-		return nil, result
-
 	default:
 		return nil, runtime.NewAPIError("unknown error", response, response.Code())
 	}
@@ -142,27 +135,6 @@ func (o *WeaviateActionsDeleteNotFound) Error() string {
 }
 
 func (o *WeaviateActionsDeleteNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
-	return nil
-}
-
-// NewWeaviateActionsDeleteNotImplemented creates a WeaviateActionsDeleteNotImplemented with default headers values
-func NewWeaviateActionsDeleteNotImplemented() *WeaviateActionsDeleteNotImplemented {
-	return &WeaviateActionsDeleteNotImplemented{}
-}
-
-/*WeaviateActionsDeleteNotImplemented handles this case with default header values.
-
-Not (yet) implemented.
-*/
-type WeaviateActionsDeleteNotImplemented struct {
-}
-
-func (o *WeaviateActionsDeleteNotImplemented) Error() string {
-	return fmt.Sprintf("[DELETE /actions/{actionId}][%d] weaviateActionsDeleteNotImplemented ", 501)
-}
-
-func (o *WeaviateActionsDeleteNotImplemented) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	return nil
 }

--- a/client/actions/weaviate_actions_get_responses.go
+++ b/client/actions/weaviate_actions_get_responses.go
@@ -53,13 +53,6 @@ func (o *WeaviateActionsGetReader) ReadResponse(response runtime.ClientResponse,
 		}
 		return nil, result
 
-	case 501:
-		result := NewWeaviateActionsGetNotImplemented()
-		if err := result.readResponse(response, consumer, o.formats); err != nil {
-			return nil, err
-		}
-		return nil, result
-
 	default:
 		return nil, runtime.NewAPIError("unknown error", response, response.Code())
 	}
@@ -153,27 +146,6 @@ func (o *WeaviateActionsGetNotFound) Error() string {
 }
 
 func (o *WeaviateActionsGetNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
-	return nil
-}
-
-// NewWeaviateActionsGetNotImplemented creates a WeaviateActionsGetNotImplemented with default headers values
-func NewWeaviateActionsGetNotImplemented() *WeaviateActionsGetNotImplemented {
-	return &WeaviateActionsGetNotImplemented{}
-}
-
-/*WeaviateActionsGetNotImplemented handles this case with default header values.
-
-Not (yet) implemented.
-*/
-type WeaviateActionsGetNotImplemented struct {
-}
-
-func (o *WeaviateActionsGetNotImplemented) Error() string {
-	return fmt.Sprintf("[GET /actions/{actionId}][%d] weaviateActionsGetNotImplemented ", 501)
-}
-
-func (o *WeaviateActionsGetNotImplemented) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	return nil
 }

--- a/client/actions/weaviate_actions_patch_responses.go
+++ b/client/actions/weaviate_actions_patch_responses.go
@@ -67,13 +67,6 @@ func (o *WeaviateActionsPatchReader) ReadResponse(response runtime.ClientRespons
 		}
 		return nil, result
 
-	case 501:
-		result := NewWeaviateActionsPatchNotImplemented()
-		if err := result.readResponse(response, consumer, o.formats); err != nil {
-			return nil, err
-		}
-		return nil, result
-
 	default:
 		return nil, runtime.NewAPIError("unknown error", response, response.Code())
 	}
@@ -217,27 +210,6 @@ func (o *WeaviateActionsPatchUnprocessableEntity) readResponse(response runtime.
 	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
 		return err
 	}
-
-	return nil
-}
-
-// NewWeaviateActionsPatchNotImplemented creates a WeaviateActionsPatchNotImplemented with default headers values
-func NewWeaviateActionsPatchNotImplemented() *WeaviateActionsPatchNotImplemented {
-	return &WeaviateActionsPatchNotImplemented{}
-}
-
-/*WeaviateActionsPatchNotImplemented handles this case with default header values.
-
-Not (yet) implemented.
-*/
-type WeaviateActionsPatchNotImplemented struct {
-}
-
-func (o *WeaviateActionsPatchNotImplemented) Error() string {
-	return fmt.Sprintf("[PATCH /actions/{actionId}][%d] weaviateActionsPatchNotImplemented ", 501)
-}
-
-func (o *WeaviateActionsPatchNotImplemented) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	return nil
 }

--- a/client/actions/weaviate_actions_validate_responses.go
+++ b/client/actions/weaviate_actions_validate_responses.go
@@ -53,13 +53,6 @@ func (o *WeaviateActionsValidateReader) ReadResponse(response runtime.ClientResp
 		}
 		return nil, result
 
-	case 501:
-		result := NewWeaviateActionsValidateNotImplemented()
-		if err := result.readResponse(response, consumer, o.formats); err != nil {
-			return nil, err
-		}
-		return nil, result
-
 	default:
 		return nil, runtime.NewAPIError("unknown error", response, response.Code())
 	}
@@ -153,27 +146,6 @@ func (o *WeaviateActionsValidateUnprocessableEntity) readResponse(response runti
 	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
 		return err
 	}
-
-	return nil
-}
-
-// NewWeaviateActionsValidateNotImplemented creates a WeaviateActionsValidateNotImplemented with default headers values
-func NewWeaviateActionsValidateNotImplemented() *WeaviateActionsValidateNotImplemented {
-	return &WeaviateActionsValidateNotImplemented{}
-}
-
-/*WeaviateActionsValidateNotImplemented handles this case with default header values.
-
-Not (yet) implemented.
-*/
-type WeaviateActionsValidateNotImplemented struct {
-}
-
-func (o *WeaviateActionsValidateNotImplemented) Error() string {
-	return fmt.Sprintf("[POST /actions/validate][%d] weaviateActionsValidateNotImplemented ", 501)
-}
-
-func (o *WeaviateActionsValidateNotImplemented) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	return nil
 }

--- a/client/graphql/weaviate_graphql_post_responses.go
+++ b/client/graphql/weaviate_graphql_post_responses.go
@@ -53,13 +53,6 @@ func (o *WeaviateGraphqlPostReader) ReadResponse(response runtime.ClientResponse
 		}
 		return nil, result
 
-	case 501:
-		result := NewWeaviateGraphqlPostNotImplemented()
-		if err := result.readResponse(response, consumer, o.formats); err != nil {
-			return nil, err
-		}
-		return nil, result
-
 	default:
 		return nil, runtime.NewAPIError("unknown error", response, response.Code())
 	}
@@ -161,27 +154,6 @@ func (o *WeaviateGraphqlPostUnprocessableEntity) readResponse(response runtime.C
 	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
 		return err
 	}
-
-	return nil
-}
-
-// NewWeaviateGraphqlPostNotImplemented creates a WeaviateGraphqlPostNotImplemented with default headers values
-func NewWeaviateGraphqlPostNotImplemented() *WeaviateGraphqlPostNotImplemented {
-	return &WeaviateGraphqlPostNotImplemented{}
-}
-
-/*WeaviateGraphqlPostNotImplemented handles this case with default header values.
-
-Not (yet) implemented.
-*/
-type WeaviateGraphqlPostNotImplemented struct {
-}
-
-func (o *WeaviateGraphqlPostNotImplemented) Error() string {
-	return fmt.Sprintf("[POST /graphql][%d] weaviateGraphqlPostNotImplemented ", 501)
-}
-
-func (o *WeaviateGraphqlPostNotImplemented) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	return nil
 }

--- a/client/keys/weaviate_key_create_responses.go
+++ b/client/keys/weaviate_key_create_responses.go
@@ -46,13 +46,6 @@ func (o *WeaviateKeyCreateReader) ReadResponse(response runtime.ClientResponse, 
 		}
 		return nil, result
 
-	case 501:
-		result := NewWeaviateKeyCreateNotImplemented()
-		if err := result.readResponse(response, consumer, o.formats); err != nil {
-			return nil, err
-		}
-		return nil, result
-
 	default:
 		return nil, runtime.NewAPIError("unknown error", response, response.Code())
 	}
@@ -133,27 +126,6 @@ func (o *WeaviateKeyCreateUnprocessableEntity) readResponse(response runtime.Cli
 	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
 		return err
 	}
-
-	return nil
-}
-
-// NewWeaviateKeyCreateNotImplemented creates a WeaviateKeyCreateNotImplemented with default headers values
-func NewWeaviateKeyCreateNotImplemented() *WeaviateKeyCreateNotImplemented {
-	return &WeaviateKeyCreateNotImplemented{}
-}
-
-/*WeaviateKeyCreateNotImplemented handles this case with default header values.
-
-Not (yet) implemented.
-*/
-type WeaviateKeyCreateNotImplemented struct {
-}
-
-func (o *WeaviateKeyCreateNotImplemented) Error() string {
-	return fmt.Sprintf("[POST /keys][%d] weaviateKeyCreateNotImplemented ", 501)
-}
-
-func (o *WeaviateKeyCreateNotImplemented) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	return nil
 }

--- a/client/keys/weaviate_keys_children_get_responses.go
+++ b/client/keys/weaviate_keys_children_get_responses.go
@@ -53,13 +53,6 @@ func (o *WeaviateKeysChildrenGetReader) ReadResponse(response runtime.ClientResp
 		}
 		return nil, result
 
-	case 501:
-		result := NewWeaviateKeysChildrenGetNotImplemented()
-		if err := result.readResponse(response, consumer, o.formats); err != nil {
-			return nil, err
-		}
-		return nil, result
-
 	default:
 		return nil, runtime.NewAPIError("unknown error", response, response.Code())
 	}
@@ -153,27 +146,6 @@ func (o *WeaviateKeysChildrenGetNotFound) Error() string {
 }
 
 func (o *WeaviateKeysChildrenGetNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
-	return nil
-}
-
-// NewWeaviateKeysChildrenGetNotImplemented creates a WeaviateKeysChildrenGetNotImplemented with default headers values
-func NewWeaviateKeysChildrenGetNotImplemented() *WeaviateKeysChildrenGetNotImplemented {
-	return &WeaviateKeysChildrenGetNotImplemented{}
-}
-
-/*WeaviateKeysChildrenGetNotImplemented handles this case with default header values.
-
-Not (yet) implemented
-*/
-type WeaviateKeysChildrenGetNotImplemented struct {
-}
-
-func (o *WeaviateKeysChildrenGetNotImplemented) Error() string {
-	return fmt.Sprintf("[GET /keys/{keyId}/children][%d] weaviateKeysChildrenGetNotImplemented ", 501)
-}
-
-func (o *WeaviateKeysChildrenGetNotImplemented) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	return nil
 }

--- a/client/keys/weaviate_keys_delete_responses.go
+++ b/client/keys/weaviate_keys_delete_responses.go
@@ -50,13 +50,6 @@ func (o *WeaviateKeysDeleteReader) ReadResponse(response runtime.ClientResponse,
 		}
 		return nil, result
 
-	case 501:
-		result := NewWeaviateKeysDeleteNotImplemented()
-		if err := result.readResponse(response, consumer, o.formats); err != nil {
-			return nil, err
-		}
-		return nil, result
-
 	default:
 		return nil, runtime.NewAPIError("unknown error", response, response.Code())
 	}
@@ -142,27 +135,6 @@ func (o *WeaviateKeysDeleteNotFound) Error() string {
 }
 
 func (o *WeaviateKeysDeleteNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
-	return nil
-}
-
-// NewWeaviateKeysDeleteNotImplemented creates a WeaviateKeysDeleteNotImplemented with default headers values
-func NewWeaviateKeysDeleteNotImplemented() *WeaviateKeysDeleteNotImplemented {
-	return &WeaviateKeysDeleteNotImplemented{}
-}
-
-/*WeaviateKeysDeleteNotImplemented handles this case with default header values.
-
-Not (yet) implemented.
-*/
-type WeaviateKeysDeleteNotImplemented struct {
-}
-
-func (o *WeaviateKeysDeleteNotImplemented) Error() string {
-	return fmt.Sprintf("[DELETE /keys/{keyId}][%d] weaviateKeysDeleteNotImplemented ", 501)
-}
-
-func (o *WeaviateKeysDeleteNotImplemented) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	return nil
 }

--- a/client/keys/weaviate_keys_get_responses.go
+++ b/client/keys/weaviate_keys_get_responses.go
@@ -53,13 +53,6 @@ func (o *WeaviateKeysGetReader) ReadResponse(response runtime.ClientResponse, co
 		}
 		return nil, result
 
-	case 501:
-		result := NewWeaviateKeysGetNotImplemented()
-		if err := result.readResponse(response, consumer, o.formats); err != nil {
-			return nil, err
-		}
-		return nil, result
-
 	default:
 		return nil, runtime.NewAPIError("unknown error", response, response.Code())
 	}
@@ -153,27 +146,6 @@ func (o *WeaviateKeysGetNotFound) Error() string {
 }
 
 func (o *WeaviateKeysGetNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
-	return nil
-}
-
-// NewWeaviateKeysGetNotImplemented creates a WeaviateKeysGetNotImplemented with default headers values
-func NewWeaviateKeysGetNotImplemented() *WeaviateKeysGetNotImplemented {
-	return &WeaviateKeysGetNotImplemented{}
-}
-
-/*WeaviateKeysGetNotImplemented handles this case with default header values.
-
-Not (yet) implemented.
-*/
-type WeaviateKeysGetNotImplemented struct {
-}
-
-func (o *WeaviateKeysGetNotImplemented) Error() string {
-	return fmt.Sprintf("[GET /keys/{keyId}][%d] weaviateKeysGetNotImplemented ", 501)
-}
-
-func (o *WeaviateKeysGetNotImplemented) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	return nil
 }

--- a/client/keys/weaviate_keys_me_children_get_responses.go
+++ b/client/keys/weaviate_keys_me_children_get_responses.go
@@ -46,13 +46,6 @@ func (o *WeaviateKeysMeChildrenGetReader) ReadResponse(response runtime.ClientRe
 		}
 		return nil, result
 
-	case 501:
-		result := NewWeaviateKeysMeChildrenGetNotImplemented()
-		if err := result.readResponse(response, consumer, o.formats); err != nil {
-			return nil, err
-		}
-		return nil, result
-
 	default:
 		return nil, runtime.NewAPIError("unknown error", response, response.Code())
 	}
@@ -125,27 +118,6 @@ func (o *WeaviateKeysMeChildrenGetNotFound) Error() string {
 }
 
 func (o *WeaviateKeysMeChildrenGetNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
-	return nil
-}
-
-// NewWeaviateKeysMeChildrenGetNotImplemented creates a WeaviateKeysMeChildrenGetNotImplemented with default headers values
-func NewWeaviateKeysMeChildrenGetNotImplemented() *WeaviateKeysMeChildrenGetNotImplemented {
-	return &WeaviateKeysMeChildrenGetNotImplemented{}
-}
-
-/*WeaviateKeysMeChildrenGetNotImplemented handles this case with default header values.
-
-Not (yet) implemented
-*/
-type WeaviateKeysMeChildrenGetNotImplemented struct {
-}
-
-func (o *WeaviateKeysMeChildrenGetNotImplemented) Error() string {
-	return fmt.Sprintf("[GET /keys/me/children][%d] weaviateKeysMeChildrenGetNotImplemented ", 501)
-}
-
-func (o *WeaviateKeysMeChildrenGetNotImplemented) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	return nil
 }

--- a/client/keys/weaviate_keys_me_get_responses.go
+++ b/client/keys/weaviate_keys_me_get_responses.go
@@ -46,13 +46,6 @@ func (o *WeaviateKeysMeGetReader) ReadResponse(response runtime.ClientResponse, 
 		}
 		return nil, result
 
-	case 501:
-		result := NewWeaviateKeysMeGetNotImplemented()
-		if err := result.readResponse(response, consumer, o.formats); err != nil {
-			return nil, err
-		}
-		return nil, result
-
 	default:
 		return nil, runtime.NewAPIError("unknown error", response, response.Code())
 	}
@@ -125,27 +118,6 @@ func (o *WeaviateKeysMeGetNotFound) Error() string {
 }
 
 func (o *WeaviateKeysMeGetNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
-	return nil
-}
-
-// NewWeaviateKeysMeGetNotImplemented creates a WeaviateKeysMeGetNotImplemented with default headers values
-func NewWeaviateKeysMeGetNotImplemented() *WeaviateKeysMeGetNotImplemented {
-	return &WeaviateKeysMeGetNotImplemented{}
-}
-
-/*WeaviateKeysMeGetNotImplemented handles this case with default header values.
-
-Not (yet) implemented.
-*/
-type WeaviateKeysMeGetNotImplemented struct {
-}
-
-func (o *WeaviateKeysMeGetNotImplemented) Error() string {
-	return fmt.Sprintf("[GET /keys/me][%d] weaviateKeysMeGetNotImplemented ", 501)
-}
-
-func (o *WeaviateKeysMeGetNotImplemented) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	return nil
 }

--- a/client/keys/weaviate_keys_renew_token_responses.go
+++ b/client/keys/weaviate_keys_renew_token_responses.go
@@ -60,13 +60,6 @@ func (o *WeaviateKeysRenewTokenReader) ReadResponse(response runtime.ClientRespo
 		}
 		return nil, result
 
-	case 501:
-		result := NewWeaviateKeysRenewTokenNotImplemented()
-		if err := result.readResponse(response, consumer, o.formats); err != nil {
-			return nil, err
-		}
-		return nil, result
-
 	default:
 		return nil, runtime.NewAPIError("unknown error", response, response.Code())
 	}
@@ -189,27 +182,6 @@ func (o *WeaviateKeysRenewTokenUnprocessableEntity) readResponse(response runtim
 	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
 		return err
 	}
-
-	return nil
-}
-
-// NewWeaviateKeysRenewTokenNotImplemented creates a WeaviateKeysRenewTokenNotImplemented with default headers values
-func NewWeaviateKeysRenewTokenNotImplemented() *WeaviateKeysRenewTokenNotImplemented {
-	return &WeaviateKeysRenewTokenNotImplemented{}
-}
-
-/*WeaviateKeysRenewTokenNotImplemented handles this case with default header values.
-
-Not (yet) implemented.
-*/
-type WeaviateKeysRenewTokenNotImplemented struct {
-}
-
-func (o *WeaviateKeysRenewTokenNotImplemented) Error() string {
-	return fmt.Sprintf("[PUT /keys/{keyId}/renew-token][%d] weaviateKeysRenewTokenNotImplemented ", 501)
-}
-
-func (o *WeaviateKeysRenewTokenNotImplemented) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	return nil
 }

--- a/client/meta/weaviate_meta_get_responses.go
+++ b/client/meta/weaviate_meta_get_responses.go
@@ -39,13 +39,6 @@ func (o *WeaviateMetaGetReader) ReadResponse(response runtime.ClientResponse, co
 		}
 		return nil, result
 
-	case 501:
-		result := NewWeaviateMetaGetNotImplemented()
-		if err := result.readResponse(response, consumer, o.formats); err != nil {
-			return nil, err
-		}
-		return nil, result
-
 	default:
 		return nil, runtime.NewAPIError("unknown error", response, response.Code())
 	}
@@ -97,27 +90,6 @@ func (o *WeaviateMetaGetUnauthorized) Error() string {
 }
 
 func (o *WeaviateMetaGetUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
-	return nil
-}
-
-// NewWeaviateMetaGetNotImplemented creates a WeaviateMetaGetNotImplemented with default headers values
-func NewWeaviateMetaGetNotImplemented() *WeaviateMetaGetNotImplemented {
-	return &WeaviateMetaGetNotImplemented{}
-}
-
-/*WeaviateMetaGetNotImplemented handles this case with default header values.
-
-Not (yet) implemented
-*/
-type WeaviateMetaGetNotImplemented struct {
-}
-
-func (o *WeaviateMetaGetNotImplemented) Error() string {
-	return fmt.Sprintf("[GET /meta][%d] weaviateMetaGetNotImplemented ", 501)
-}
-
-func (o *WeaviateMetaGetNotImplemented) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	return nil
 }

--- a/client/things/things_client.go
+++ b/client/things/things_client.go
@@ -91,7 +91,7 @@ WeaviateThingsCreate creates a new thing based on a thing template related to th
 
 Registers a new thing. Given meta-data and schema values are validated.
 */
-func (a *Client) WeaviateThingsCreate(params *WeaviateThingsCreateParams, authInfo runtime.ClientAuthInfoWriter) (*WeaviateThingsCreateAccepted, error) {
+func (a *Client) WeaviateThingsCreate(params *WeaviateThingsCreateParams, authInfo runtime.ClientAuthInfoWriter) (*WeaviateThingsCreateOK, *WeaviateThingsCreateAccepted, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewWeaviateThingsCreateParams()
@@ -111,9 +111,15 @@ func (a *Client) WeaviateThingsCreate(params *WeaviateThingsCreateParams, authIn
 		Client:             params.HTTPClient,
 	})
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return result.(*WeaviateThingsCreateAccepted), nil
+	switch value := result.(type) {
+	case *WeaviateThingsCreateOK:
+		return value, nil, nil
+	case *WeaviateThingsCreateAccepted:
+		return nil, value, nil
+	}
+	return nil, nil, nil
 
 }
 

--- a/client/things/weaviate_things_actions_list_responses.go
+++ b/client/things/weaviate_things_actions_list_responses.go
@@ -53,13 +53,6 @@ func (o *WeaviateThingsActionsListReader) ReadResponse(response runtime.ClientRe
 		}
 		return nil, result
 
-	case 501:
-		result := NewWeaviateThingsActionsListNotImplemented()
-		if err := result.readResponse(response, consumer, o.formats); err != nil {
-			return nil, err
-		}
-		return nil, result
-
 	default:
 		return nil, runtime.NewAPIError("unknown error", response, response.Code())
 	}
@@ -153,27 +146,6 @@ func (o *WeaviateThingsActionsListNotFound) Error() string {
 }
 
 func (o *WeaviateThingsActionsListNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
-	return nil
-}
-
-// NewWeaviateThingsActionsListNotImplemented creates a WeaviateThingsActionsListNotImplemented with default headers values
-func NewWeaviateThingsActionsListNotImplemented() *WeaviateThingsActionsListNotImplemented {
-	return &WeaviateThingsActionsListNotImplemented{}
-}
-
-/*WeaviateThingsActionsListNotImplemented handles this case with default header values.
-
-Not (yet) implemented.
-*/
-type WeaviateThingsActionsListNotImplemented struct {
-}
-
-func (o *WeaviateThingsActionsListNotImplemented) Error() string {
-	return fmt.Sprintf("[GET /things/{thingId}/actions][%d] weaviateThingsActionsListNotImplemented ", 501)
-}
-
-func (o *WeaviateThingsActionsListNotImplemented) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	return nil
 }

--- a/client/things/weaviate_things_create_parameters.go
+++ b/client/things/weaviate_things_create_parameters.go
@@ -16,8 +16,6 @@ import (
 	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
-
-	models "github.com/creativesoftwarefdn/weaviate/models"
 )
 
 // NewWeaviateThingsCreateParams creates a new WeaviateThingsCreateParams object
@@ -65,7 +63,7 @@ for the weaviate things create operation typically these are written to a http.R
 type WeaviateThingsCreateParams struct {
 
 	/*Body*/
-	Body *models.ThingCreate
+	Body WeaviateThingsCreateBody
 
 	timeout    time.Duration
 	Context    context.Context
@@ -106,13 +104,13 @@ func (o *WeaviateThingsCreateParams) SetHTTPClient(client *http.Client) {
 }
 
 // WithBody adds the body to the weaviate things create params
-func (o *WeaviateThingsCreateParams) WithBody(body *models.ThingCreate) *WeaviateThingsCreateParams {
+func (o *WeaviateThingsCreateParams) WithBody(body WeaviateThingsCreateBody) *WeaviateThingsCreateParams {
 	o.SetBody(body)
 	return o
 }
 
 // SetBody adds the body to the weaviate things create params
-func (o *WeaviateThingsCreateParams) SetBody(body *models.ThingCreate) {
+func (o *WeaviateThingsCreateParams) SetBody(body WeaviateThingsCreateBody) {
 	o.Body = body
 }
 
@@ -124,10 +122,8 @@ func (o *WeaviateThingsCreateParams) WriteToRequest(r runtime.ClientRequest, reg
 	}
 	var res []error
 
-	if o.Body != nil {
-		if err := r.SetBodyParam(o.Body); err != nil {
-			return err
-		}
+	if err := r.SetBodyParam(o.Body); err != nil {
+		return err
 	}
 
 	if len(res) > 0 {

--- a/client/things/weaviate_things_create_responses.go
+++ b/client/things/weaviate_things_create_responses.go
@@ -9,7 +9,9 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	"github.com/go-openapi/swag"
 
 	strfmt "github.com/go-openapi/strfmt"
 
@@ -24,6 +26,13 @@ type WeaviateThingsCreateReader struct {
 // ReadResponse reads a server response into the received o.
 func (o *WeaviateThingsCreateReader) ReadResponse(response runtime.ClientResponse, consumer runtime.Consumer) (interface{}, error) {
 	switch response.Code() {
+
+	case 200:
+		result := NewWeaviateThingsCreateOK()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return result, nil
 
 	case 202:
 		result := NewWeaviateThingsCreateAccepted()
@@ -53,16 +62,38 @@ func (o *WeaviateThingsCreateReader) ReadResponse(response runtime.ClientRespons
 		}
 		return nil, result
 
-	case 501:
-		result := NewWeaviateThingsCreateNotImplemented()
-		if err := result.readResponse(response, consumer, o.formats); err != nil {
-			return nil, err
-		}
-		return nil, result
-
 	default:
 		return nil, runtime.NewAPIError("unknown error", response, response.Code())
 	}
+}
+
+// NewWeaviateThingsCreateOK creates a WeaviateThingsCreateOK with default headers values
+func NewWeaviateThingsCreateOK() *WeaviateThingsCreateOK {
+	return &WeaviateThingsCreateOK{}
+}
+
+/*WeaviateThingsCreateOK handles this case with default header values.
+
+Thing created.
+*/
+type WeaviateThingsCreateOK struct {
+	Payload *models.ThingGetResponse
+}
+
+func (o *WeaviateThingsCreateOK) Error() string {
+	return fmt.Sprintf("[POST /things][%d] weaviateThingsCreateOK  %+v", 200, o.Payload)
+}
+
+func (o *WeaviateThingsCreateOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(models.ThingGetResponse)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
 }
 
 // NewWeaviateThingsCreateAccepted creates a WeaviateThingsCreateAccepted with default headers values
@@ -165,23 +196,64 @@ func (o *WeaviateThingsCreateUnprocessableEntity) readResponse(response runtime.
 	return nil
 }
 
-// NewWeaviateThingsCreateNotImplemented creates a WeaviateThingsCreateNotImplemented with default headers values
-func NewWeaviateThingsCreateNotImplemented() *WeaviateThingsCreateNotImplemented {
-	return &WeaviateThingsCreateNotImplemented{}
-}
-
-/*WeaviateThingsCreateNotImplemented handles this case with default header values.
-
-Not (yet) implemented.
+/*WeaviateThingsCreateBody weaviate things create body
+swagger:model WeaviateThingsCreateBody
 */
-type WeaviateThingsCreateNotImplemented struct {
+type WeaviateThingsCreateBody struct {
+
+	// If `async` is true, return a 202 with the new ID of the Thing. You will receive this response before the data is persisted. If `async` is false, you will receive confirmation after the value is persisted. The value of `async` defaults to false.
+	Async bool `json:"async,omitempty"`
+
+	// thing
+	Thing *models.ThingCreate `json:"thing,omitempty"`
 }
 
-func (o *WeaviateThingsCreateNotImplemented) Error() string {
-	return fmt.Sprintf("[POST /things][%d] weaviateThingsCreateNotImplemented ", 501)
+// Validate validates this weaviate things create body
+func (o *WeaviateThingsCreateBody) Validate(formats strfmt.Registry) error {
+	var res []error
+
+	if err := o.validateThing(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
 }
 
-func (o *WeaviateThingsCreateNotImplemented) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+func (o *WeaviateThingsCreateBody) validateThing(formats strfmt.Registry) error {
 
+	if swag.IsZero(o.Thing) { // not required
+		return nil
+	}
+
+	if o.Thing != nil {
+		if err := o.Thing.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("body" + "." + "thing")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+// MarshalBinary interface implementation
+func (o *WeaviateThingsCreateBody) MarshalBinary() ([]byte, error) {
+	if o == nil {
+		return nil, nil
+	}
+	return swag.WriteJSON(o)
+}
+
+// UnmarshalBinary interface implementation
+func (o *WeaviateThingsCreateBody) UnmarshalBinary(b []byte) error {
+	var res WeaviateThingsCreateBody
+	if err := swag.ReadJSON(b, &res); err != nil {
+		return err
+	}
+	*o = res
 	return nil
 }

--- a/client/things/weaviate_things_delete_responses.go
+++ b/client/things/weaviate_things_delete_responses.go
@@ -50,13 +50,6 @@ func (o *WeaviateThingsDeleteReader) ReadResponse(response runtime.ClientRespons
 		}
 		return nil, result
 
-	case 501:
-		result := NewWeaviateThingsDeleteNotImplemented()
-		if err := result.readResponse(response, consumer, o.formats); err != nil {
-			return nil, err
-		}
-		return nil, result
-
 	default:
 		return nil, runtime.NewAPIError("unknown error", response, response.Code())
 	}
@@ -142,27 +135,6 @@ func (o *WeaviateThingsDeleteNotFound) Error() string {
 }
 
 func (o *WeaviateThingsDeleteNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
-	return nil
-}
-
-// NewWeaviateThingsDeleteNotImplemented creates a WeaviateThingsDeleteNotImplemented with default headers values
-func NewWeaviateThingsDeleteNotImplemented() *WeaviateThingsDeleteNotImplemented {
-	return &WeaviateThingsDeleteNotImplemented{}
-}
-
-/*WeaviateThingsDeleteNotImplemented handles this case with default header values.
-
-Not (yet) implemented.
-*/
-type WeaviateThingsDeleteNotImplemented struct {
-}
-
-func (o *WeaviateThingsDeleteNotImplemented) Error() string {
-	return fmt.Sprintf("[DELETE /things/{thingId}][%d] weaviateThingsDeleteNotImplemented ", 501)
-}
-
-func (o *WeaviateThingsDeleteNotImplemented) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	return nil
 }

--- a/client/things/weaviate_things_get_responses.go
+++ b/client/things/weaviate_things_get_responses.go
@@ -53,13 +53,6 @@ func (o *WeaviateThingsGetReader) ReadResponse(response runtime.ClientResponse, 
 		}
 		return nil, result
 
-	case 501:
-		result := NewWeaviateThingsGetNotImplemented()
-		if err := result.readResponse(response, consumer, o.formats); err != nil {
-			return nil, err
-		}
-		return nil, result
-
 	default:
 		return nil, runtime.NewAPIError("unknown error", response, response.Code())
 	}
@@ -153,27 +146,6 @@ func (o *WeaviateThingsGetNotFound) Error() string {
 }
 
 func (o *WeaviateThingsGetNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
-	return nil
-}
-
-// NewWeaviateThingsGetNotImplemented creates a WeaviateThingsGetNotImplemented with default headers values
-func NewWeaviateThingsGetNotImplemented() *WeaviateThingsGetNotImplemented {
-	return &WeaviateThingsGetNotImplemented{}
-}
-
-/*WeaviateThingsGetNotImplemented handles this case with default header values.
-
-Not (yet) implemented.
-*/
-type WeaviateThingsGetNotImplemented struct {
-}
-
-func (o *WeaviateThingsGetNotImplemented) Error() string {
-	return fmt.Sprintf("[GET /things/{thingId}][%d] weaviateThingsGetNotImplemented ", 501)
-}
-
-func (o *WeaviateThingsGetNotImplemented) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	return nil
 }

--- a/client/things/weaviate_things_list_responses.go
+++ b/client/things/weaviate_things_list_responses.go
@@ -53,13 +53,6 @@ func (o *WeaviateThingsListReader) ReadResponse(response runtime.ClientResponse,
 		}
 		return nil, result
 
-	case 501:
-		result := NewWeaviateThingsListNotImplemented()
-		if err := result.readResponse(response, consumer, o.formats); err != nil {
-			return nil, err
-		}
-		return nil, result
-
 	default:
 		return nil, runtime.NewAPIError("unknown error", response, response.Code())
 	}
@@ -153,27 +146,6 @@ func (o *WeaviateThingsListNotFound) Error() string {
 }
 
 func (o *WeaviateThingsListNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
-	return nil
-}
-
-// NewWeaviateThingsListNotImplemented creates a WeaviateThingsListNotImplemented with default headers values
-func NewWeaviateThingsListNotImplemented() *WeaviateThingsListNotImplemented {
-	return &WeaviateThingsListNotImplemented{}
-}
-
-/*WeaviateThingsListNotImplemented handles this case with default header values.
-
-Not (yet) implemented.
-*/
-type WeaviateThingsListNotImplemented struct {
-}
-
-func (o *WeaviateThingsListNotImplemented) Error() string {
-	return fmt.Sprintf("[GET /things][%d] weaviateThingsListNotImplemented ", 501)
-}
-
-func (o *WeaviateThingsListNotImplemented) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	return nil
 }

--- a/client/things/weaviate_things_patch_responses.go
+++ b/client/things/weaviate_things_patch_responses.go
@@ -67,13 +67,6 @@ func (o *WeaviateThingsPatchReader) ReadResponse(response runtime.ClientResponse
 		}
 		return nil, result
 
-	case 501:
-		result := NewWeaviateThingsPatchNotImplemented()
-		if err := result.readResponse(response, consumer, o.formats); err != nil {
-			return nil, err
-		}
-		return nil, result
-
 	default:
 		return nil, runtime.NewAPIError("unknown error", response, response.Code())
 	}
@@ -217,27 +210,6 @@ func (o *WeaviateThingsPatchUnprocessableEntity) readResponse(response runtime.C
 	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
 		return err
 	}
-
-	return nil
-}
-
-// NewWeaviateThingsPatchNotImplemented creates a WeaviateThingsPatchNotImplemented with default headers values
-func NewWeaviateThingsPatchNotImplemented() *WeaviateThingsPatchNotImplemented {
-	return &WeaviateThingsPatchNotImplemented{}
-}
-
-/*WeaviateThingsPatchNotImplemented handles this case with default header values.
-
-Not (yet) implemented.
-*/
-type WeaviateThingsPatchNotImplemented struct {
-}
-
-func (o *WeaviateThingsPatchNotImplemented) Error() string {
-	return fmt.Sprintf("[PATCH /things/{thingId}][%d] weaviateThingsPatchNotImplemented ", 501)
-}
-
-func (o *WeaviateThingsPatchNotImplemented) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	return nil
 }

--- a/client/things/weaviate_things_update_responses.go
+++ b/client/things/weaviate_things_update_responses.go
@@ -60,13 +60,6 @@ func (o *WeaviateThingsUpdateReader) ReadResponse(response runtime.ClientRespons
 		}
 		return nil, result
 
-	case 501:
-		result := NewWeaviateThingsUpdateNotImplemented()
-		if err := result.readResponse(response, consumer, o.formats); err != nil {
-			return nil, err
-		}
-		return nil, result
-
 	default:
 		return nil, runtime.NewAPIError("unknown error", response, response.Code())
 	}
@@ -189,27 +182,6 @@ func (o *WeaviateThingsUpdateUnprocessableEntity) readResponse(response runtime.
 	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
 		return err
 	}
-
-	return nil
-}
-
-// NewWeaviateThingsUpdateNotImplemented creates a WeaviateThingsUpdateNotImplemented with default headers values
-func NewWeaviateThingsUpdateNotImplemented() *WeaviateThingsUpdateNotImplemented {
-	return &WeaviateThingsUpdateNotImplemented{}
-}
-
-/*WeaviateThingsUpdateNotImplemented handles this case with default header values.
-
-Not (yet) implemented.
-*/
-type WeaviateThingsUpdateNotImplemented struct {
-}
-
-func (o *WeaviateThingsUpdateNotImplemented) Error() string {
-	return fmt.Sprintf("[PUT /things/{thingId}][%d] weaviateThingsUpdateNotImplemented ", 501)
-}
-
-func (o *WeaviateThingsUpdateNotImplemented) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	return nil
 }

--- a/client/things/weaviate_things_validate_responses.go
+++ b/client/things/weaviate_things_validate_responses.go
@@ -53,13 +53,6 @@ func (o *WeaviateThingsValidateReader) ReadResponse(response runtime.ClientRespo
 		}
 		return nil, result
 
-	case 501:
-		result := NewWeaviateThingsValidateNotImplemented()
-		if err := result.readResponse(response, consumer, o.formats); err != nil {
-			return nil, err
-		}
-		return nil, result
-
 	default:
 		return nil, runtime.NewAPIError("unknown error", response, response.Code())
 	}
@@ -153,27 +146,6 @@ func (o *WeaviateThingsValidateUnprocessableEntity) readResponse(response runtim
 	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
 		return err
 	}
-
-	return nil
-}
-
-// NewWeaviateThingsValidateNotImplemented creates a WeaviateThingsValidateNotImplemented with default headers values
-func NewWeaviateThingsValidateNotImplemented() *WeaviateThingsValidateNotImplemented {
-	return &WeaviateThingsValidateNotImplemented{}
-}
-
-/*WeaviateThingsValidateNotImplemented handles this case with default header values.
-
-Not (yet) implemented.
-*/
-type WeaviateThingsValidateNotImplemented struct {
-}
-
-func (o *WeaviateThingsValidateNotImplemented) Error() string {
-	return fmt.Sprintf("[POST /things/validate][%d] weaviateThingsValidateNotImplemented ", 501)
-}
-
-func (o *WeaviateThingsValidateNotImplemented) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	return nil
 }

--- a/openapi-specs/schema.json
+++ b/openapi-specs/schema.json
@@ -776,14 +776,30 @@
             "in": "body",
             "name": "body",
             "required": true,
+
             "schema": {
-              "$ref": "#/definitions/ActionCreate"
+               "type": "object",
+               "properties": {
+                 "action": {
+                   "$ref": "#/definitions/ActionCreate"
+                 },
+                 "async": {
+                   "type": "boolean",
+                   "description": "If `async` is true, return a 202 with the new ID of the Action. You will receive this response before the data is persisted. If `async` is false, you will receive confirmation after the value is persisted. The value of `async` defaults to false."
+                 }
+               }
             }
           }
         ],
         "responses": {
+          "200": {
+            "description": "Action created",
+            "schema": {
+              "$ref": "#/definitions/ActionGetResponse"
+            }
+          },
           "202": {
-            "description": "Successfully received.",
+            "description": "Successfully received. No guarantees are made that the Action is persisted.",
             "schema": {
               "$ref": "#/definitions/ActionGetResponse"
             }
@@ -1490,11 +1506,26 @@
             "name": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/ThingCreate"
+              "type": "object",
+              "properties": {
+                "async": {
+                  "type": "boolean",
+                  "description": "If `async` is true, return a 202 with the new ID of the Thing. You will receive this response before the data is persisted. If `async` is false, you will receive confirmation after the value is persisted. The value of `async` defaults to false."
+                },
+                "thing" : {
+                  "$ref": "#/definitions/ThingCreate"
+                }
+              }
             }
           }
         ],
         "responses": {
+          "200": {
+            "description": "Thing created.",
+            "schema": {
+              "$ref": "#/definitions/ThingGetResponse"
+            }
+          },
           "202": {
             "description": "Successfully received.",
             "schema": {

--- a/openapi-specs/schema.json
+++ b/openapi-specs/schema.json
@@ -799,9 +799,6 @@
             "schema": {
               "$ref": "#/definitions/ErrorResponse"
             }
-          },
-          "501": {
-            "description": "Not (yet) implemented."
           }
         },
         "summary": "Create actions between two things (object and subject).",
@@ -841,9 +838,6 @@
             "schema": {
               "$ref": "#/definitions/ErrorResponse"
             }
-          },
-          "501": {
-            "description": "Not (yet) implemented."
           }
         },
         "summary": "Validate an action based on a schema.",
@@ -880,9 +874,6 @@
           },
           "404": {
             "description": "Successful query result but no resource was found."
-          },
-          "501": {
-            "description": "Not (yet) implemented."
           }
         },
         "summary": "Delete an action based on its uuid related to this key.",
@@ -920,9 +911,6 @@
           },
           "404": {
             "description": "Successful query result but no resource was found."
-          },
-          "501": {
-            "description": "Not (yet) implemented."
           }
         },
         "summary": "Get a specific action based on its uuid and a thing uuid related to this key. Also available as Websocket bus.",
@@ -981,9 +969,6 @@
             "schema": {
               "$ref": "#/definitions/ErrorResponse"
             }
-          },
-          "501": {
-            "description": "Not (yet) implemented."
           }
         },
         "summary": "Update an action based on its uuid (using patch semantics) related to this key.",
@@ -1035,9 +1020,6 @@
             "schema": {
               "$ref": "#/definitions/ErrorResponse"
             }
-          },
-          "501": {
-            "description": "Not (yet) implemented."
           }
         },
         "summary": "Update an action based on its uuid related to this key.",
@@ -1123,9 +1105,6 @@
             "schema": {
               "$ref": "#/definitions/ErrorResponse"
             }
-          },
-          "501": {
-            "description": "Not (yet) implemented."
           }
         },
         "summary": "Get a response based on GraphQL",
@@ -1165,9 +1144,6 @@
             "schema": {
               "$ref": "#/definitions/ErrorResponse"
             }
-          },
-          "501": {
-            "description": "Not (yet) implemented."
           }
         },
         "summary": "Create a new key related to this key.",
@@ -1194,9 +1170,6 @@
           },
           "404": {
             "description": "Successful query result but no resource was found."
-          },
-          "501": {
-            "description": "Not (yet) implemented."
           }
         },
         "summary": "Get a key based on the key used to do the request.",
@@ -1223,9 +1196,6 @@
           },
           "404": {
             "description": "Successful query result but no resource was found."
-          },
-          "501": {
-            "description": "Not (yet) implemented"
           }
         },
         "summary": "Get an object of this keys' children related to the key used for request.",
@@ -1262,9 +1232,6 @@
           },
           "404": {
             "description": "Successful query result but no resource was found."
-          },
-          "501": {
-            "description": "Not (yet) implemented."
           }
         },
         "summary": "Delete a key based on its uuid related to this key.",
@@ -1302,9 +1269,6 @@
           },
           "404": {
             "description": "Successful query result but no resource was found."
-          },
-          "501": {
-            "description": "Not (yet) implemented."
           }
         },
         "summary": "Get a key based on its uuid related to this key.",
@@ -1344,9 +1308,6 @@
           },
           "404": {
             "description": "Successful query result but no resource was found."
-          },
-          "501": {
-            "description": "Not (yet) implemented"
           }
         },
         "summary": "Get an object of this keys' children related to this key.",
@@ -1392,9 +1353,6 @@
             "schema": {
               "$ref": "#/definitions/ErrorResponse"
             }
-          },
-          "501": {
-            "description": "Not (yet) implemented."
           }
         },
         "summary": "Renews a key based on the key given in the query string.",
@@ -1421,9 +1379,6 @@
           },
           "401": {
             "description": "Unauthorized or invalid credentials."
-          },
-          "501": {
-            "description": "Not (yet) implemented"
           }
         },
         "summary": "Returns meta information of the current Weaviate instance.",
@@ -1517,9 +1472,6 @@
           },
           "404": {
             "description": "Successful query result but no resource was found."
-          },
-          "501": {
-            "description": "Not (yet) implemented."
           }
         },
         "summary": "Get a list of things related to this key.",
@@ -1560,9 +1512,6 @@
             "schema": {
               "$ref": "#/definitions/ErrorResponse"
             }
-          },
-          "501": {
-            "description": "Not (yet) implemented."
           }
         },
         "summary": "Create a new thing based on a thing template related to this key.",
@@ -1602,9 +1551,6 @@
             "schema": {
               "$ref": "#/definitions/ErrorResponse"
             }
-          },
-          "501": {
-            "description": "Not (yet) implemented."
           }
         },
         "summary": "Validate Things schema.",
@@ -1641,9 +1587,6 @@
           },
           "404": {
             "description": "Successful query result but no resource was found."
-          },
-          "501": {
-            "description": "Not (yet) implemented."
           }
         },
         "summary": "Delete a thing based on its uuid related to this key.",
@@ -1681,9 +1624,6 @@
           },
           "404": {
             "description": "Successful query result but no resource was found."
-          },
-          "501": {
-            "description": "Not (yet) implemented."
           }
         },
         "summary": "Get a thing based on its uuid related to this key.",
@@ -1742,9 +1682,6 @@
             "schema": {
               "$ref": "#/definitions/ErrorResponse"
             }
-          },
-          "501": {
-            "description": "Not (yet) implemented."
           }
         },
         "summary": "Update a thing based on its uuid (using patch semantics) related to this key.",
@@ -1796,9 +1733,6 @@
             "schema": {
               "$ref": "#/definitions/ErrorResponse"
             }
-          },
-          "501": {
-            "description": "Not (yet) implemented."
           }
         },
         "summary": "Update a thing based on its uuid related to this key.",
@@ -1844,9 +1778,6 @@
           },
           "404": {
             "description": "Successful query result but no resource was found."
-          },
-          "501": {
-            "description": "Not (yet) implemented."
           }
         },
         "summary": "Get a thing based on its uuid related to this thing. Also available as Websocket.",

--- a/restapi/configure_weaviate.go
+++ b/restapi/configure_weaviate.go
@@ -491,7 +491,7 @@ func configureAPI(api *operations.WeaviateAPI) http.Handler {
 		UUID := connutils.GenerateUUID()
 
 		// Validate schema given in body with the weaviate schema
-		validatedErr := validation.ValidateActionBody(params.HTTPRequest.Context(), params.Body, databaseSchema, dbConnector, serverConfig, principal.(*models.KeyTokenGetResponse))
+		validatedErr := validation.ValidateActionBody(params.HTTPRequest.Context(), params.Body.Action, databaseSchema, dbConnector, serverConfig, principal.(*models.KeyTokenGetResponse))
 		if validatedErr != nil {
 			return actions.NewWeaviateActionsCreateUnprocessableEntity().WithPayload(createErrorResponseObject(validatedErr.Error()))
 		}
@@ -506,9 +506,9 @@ func configureAPI(api *operations.WeaviateAPI) http.Handler {
 
 		// Make Action-Object
 		action := &models.Action{}
-		action.AtClass = params.Body.AtClass
-		action.AtContext = params.Body.AtContext
-		action.Schema = params.Body.Schema
+		action.AtClass = params.Body.Action.AtClass
+		action.AtContext = params.Body.Action.AtContext
+		action.Schema = params.Body.Action.Schema
 		action.CreationTimeUnix = connutils.NowUnix()
 		action.LastUpdateTimeUnix = 0
 		action.Key = keyRef
@@ -789,7 +789,7 @@ func configureAPI(api *operations.WeaviateAPI) http.Handler {
 		keyToken := principal.(*models.KeyTokenGetResponse)
 
 		// Validate schema given in body with the weaviate schema
-		validatedErr := validation.ValidateThingBody(params.HTTPRequest.Context(), params.Body, databaseSchema, dbConnector, serverConfig, keyToken)
+		validatedErr := validation.ValidateThingBody(params.HTTPRequest.Context(), params.Body.Thing, databaseSchema, dbConnector, serverConfig, keyToken)
 		if validatedErr != nil {
 			return things.NewWeaviateThingsCreateUnprocessableEntity().WithPayload(createErrorResponseObject(validatedErr.Error()))
 		}
@@ -804,9 +804,9 @@ func configureAPI(api *operations.WeaviateAPI) http.Handler {
 
 		// Make Thing-Object
 		thing := &models.Thing{}
-		thing.Schema = params.Body.Schema
-		thing.AtClass = params.Body.AtClass
-		thing.AtContext = params.Body.AtContext
+		thing.Schema = params.Body.Thing.Schema
+		thing.AtClass = params.Body.Thing.AtClass
+		thing.AtContext = params.Body.Thing.AtContext
 		thing.CreationTimeUnix = connutils.NowUnix()
 		thing.LastUpdateTimeUnix = 0
 		thing.Key = keyRef

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -66,13 +66,28 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/ActionCreate"
+              "type": "object",
+              "properties": {
+                "action": {
+                  "$ref": "#/definitions/ActionCreate"
+                },
+                "async": {
+                  "description": "If ` + "`" + `async` + "`" + ` is true, return a 202 with the new ID of the Action. You will receive this response before the data is persisted. If ` + "`" + `async` + "`" + ` is false, you will receive confirmation after the value is persisted. The value of ` + "`" + `async` + "`" + ` defaults to false.",
+                  "type": "boolean"
+                }
+              }
             }
           }
         ],
         "responses": {
+          "200": {
+            "description": "Action created",
+            "schema": {
+              "$ref": "#/definitions/ActionGetResponse"
+            }
+          },
           "202": {
-            "description": "Successfully received.",
+            "description": "Successfully received. No guarantees are made that the Action is persisted.",
             "schema": {
               "$ref": "#/definitions/ActionGetResponse"
             }
@@ -88,9 +103,6 @@ func init() {
             "schema": {
               "$ref": "#/definitions/ErrorResponse"
             }
-          },
-          "501": {
-            "description": "Not (yet) implemented."
           }
         },
         "x-available-in-mqtt": false,
@@ -130,9 +142,6 @@ func init() {
             "schema": {
               "$ref": "#/definitions/ErrorResponse"
             }
-          },
-          "501": {
-            "description": "Not (yet) implemented."
           }
         },
         "x-available-in-mqtt": false,
@@ -172,9 +181,6 @@ func init() {
           },
           "404": {
             "description": "Successful query result but no resource was found."
-          },
-          "501": {
-            "description": "Not (yet) implemented."
           }
         },
         "x-available-in-mqtt": false,
@@ -226,9 +232,6 @@ func init() {
             "schema": {
               "$ref": "#/definitions/ErrorResponse"
             }
-          },
-          "501": {
-            "description": "Not (yet) implemented."
           }
         },
         "x-available-in-mqtt": false,
@@ -263,9 +266,6 @@ func init() {
           },
           "404": {
             "description": "Successful query result but no resource was found."
-          },
-          "501": {
-            "description": "Not (yet) implemented."
           }
         },
         "x-available-in-mqtt": true,
@@ -324,9 +324,6 @@ func init() {
             "schema": {
               "$ref": "#/definitions/ErrorResponse"
             }
-          },
-          "501": {
-            "description": "Not (yet) implemented."
           }
         },
         "x-available-in-mqtt": false,
@@ -412,9 +409,6 @@ func init() {
             "schema": {
               "$ref": "#/definitions/ErrorResponse"
             }
-          },
-          "501": {
-            "description": "Not (yet) implemented."
           }
         },
         "x-available-in-mqtt": false,
@@ -454,9 +448,6 @@ func init() {
             "schema": {
               "$ref": "#/definitions/ErrorResponse"
             }
-          },
-          "501": {
-            "description": "Not (yet) implemented."
           }
         },
         "x-available-in-mqtt": false,
@@ -483,9 +474,6 @@ func init() {
           },
           "404": {
             "description": "Successful query result but no resource was found."
-          },
-          "501": {
-            "description": "Not (yet) implemented."
           }
         },
         "x-available-in-mqtt": false,
@@ -512,9 +500,6 @@ func init() {
           },
           "404": {
             "description": "Successful query result but no resource was found."
-          },
-          "501": {
-            "description": "Not (yet) implemented"
           }
         },
         "x-available-in-mqtt": false,
@@ -554,9 +539,6 @@ func init() {
           },
           "404": {
             "description": "Successful query result but no resource was found."
-          },
-          "501": {
-            "description": "Not (yet) implemented."
           }
         },
         "x-available-in-mqtt": false,
@@ -591,9 +573,6 @@ func init() {
           },
           "404": {
             "description": "Successful query result but no resource was found."
-          },
-          "501": {
-            "description": "Not (yet) implemented."
           }
         },
         "x-available-in-mqtt": false,
@@ -633,9 +612,6 @@ func init() {
           },
           "404": {
             "description": "Successful query result but no resource was found."
-          },
-          "501": {
-            "description": "Not (yet) implemented"
           }
         },
         "x-available-in-mqtt": false,
@@ -681,9 +657,6 @@ func init() {
             "schema": {
               "$ref": "#/definitions/ErrorResponse"
             }
-          },
-          "501": {
-            "description": "Not (yet) implemented."
           }
         },
         "x-available-in-mqtt": false,
@@ -710,9 +683,6 @@ func init() {
           },
           "401": {
             "description": "Unauthorized or invalid credentials."
-          },
-          "501": {
-            "description": "Not (yet) implemented"
           }
         },
         "x-available-in-mqtt": false,
@@ -804,9 +774,6 @@ func init() {
           },
           "404": {
             "description": "Successful query result but no resource was found."
-          },
-          "501": {
-            "description": "Not (yet) implemented."
           }
         },
         "x-available-in-mqtt": false,
@@ -825,11 +792,26 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/ThingCreate"
+              "type": "object",
+              "properties": {
+                "async": {
+                  "description": "If ` + "`" + `async` + "`" + ` is true, return a 202 with the new ID of the Thing. You will receive this response before the data is persisted. If ` + "`" + `async` + "`" + ` is false, you will receive confirmation after the value is persisted. The value of ` + "`" + `async` + "`" + ` defaults to false.",
+                  "type": "boolean"
+                },
+                "thing": {
+                  "$ref": "#/definitions/ThingCreate"
+                }
+              }
             }
           }
         ],
         "responses": {
+          "200": {
+            "description": "Thing created.",
+            "schema": {
+              "$ref": "#/definitions/ThingGetResponse"
+            }
+          },
           "202": {
             "description": "Successfully received.",
             "schema": {
@@ -847,9 +829,6 @@ func init() {
             "schema": {
               "$ref": "#/definitions/ErrorResponse"
             }
-          },
-          "501": {
-            "description": "Not (yet) implemented."
           }
         },
         "x-available-in-mqtt": false,
@@ -889,9 +868,6 @@ func init() {
             "schema": {
               "$ref": "#/definitions/ErrorResponse"
             }
-          },
-          "501": {
-            "description": "Not (yet) implemented."
           }
         },
         "x-available-in-mqtt": false,
@@ -931,9 +907,6 @@ func init() {
           },
           "404": {
             "description": "Successful query result but no resource was found."
-          },
-          "501": {
-            "description": "Not (yet) implemented."
           }
         },
         "x-available-in-mqtt": false,
@@ -985,9 +958,6 @@ func init() {
             "schema": {
               "$ref": "#/definitions/ErrorResponse"
             }
-          },
-          "501": {
-            "description": "Not (yet) implemented."
           }
         },
         "x-available-in-mqtt": false,
@@ -1022,9 +992,6 @@ func init() {
           },
           "404": {
             "description": "Successful query result but no resource was found."
-          },
-          "501": {
-            "description": "Not (yet) implemented."
           }
         },
         "x-available-in-mqtt": true,
@@ -1083,9 +1050,6 @@ func init() {
             "schema": {
               "$ref": "#/definitions/ErrorResponse"
             }
-          },
-          "501": {
-            "description": "Not (yet) implemented."
           }
         },
         "x-available-in-mqtt": false,
@@ -1131,9 +1095,6 @@ func init() {
           },
           "404": {
             "description": "Successful query result but no resource was found."
-          },
-          "501": {
-            "description": "Not (yet) implemented."
           }
         },
         "x-available-in-mqtt": false,
@@ -2010,13 +1971,28 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/ActionCreate"
+              "type": "object",
+              "properties": {
+                "action": {
+                  "$ref": "#/definitions/ActionCreate"
+                },
+                "async": {
+                  "description": "If ` + "`" + `async` + "`" + ` is true, return a 202 with the new ID of the Action. You will receive this response before the data is persisted. If ` + "`" + `async` + "`" + ` is false, you will receive confirmation after the value is persisted. The value of ` + "`" + `async` + "`" + ` defaults to false.",
+                  "type": "boolean"
+                }
+              }
             }
           }
         ],
         "responses": {
+          "200": {
+            "description": "Action created",
+            "schema": {
+              "$ref": "#/definitions/ActionGetResponse"
+            }
+          },
           "202": {
-            "description": "Successfully received.",
+            "description": "Successfully received. No guarantees are made that the Action is persisted.",
             "schema": {
               "$ref": "#/definitions/ActionGetResponse"
             }
@@ -2032,9 +2008,6 @@ func init() {
             "schema": {
               "$ref": "#/definitions/ErrorResponse"
             }
-          },
-          "501": {
-            "description": "Not (yet) implemented."
           }
         },
         "x-available-in-mqtt": false,
@@ -2074,9 +2047,6 @@ func init() {
             "schema": {
               "$ref": "#/definitions/ErrorResponse"
             }
-          },
-          "501": {
-            "description": "Not (yet) implemented."
           }
         },
         "x-available-in-mqtt": false,
@@ -2116,9 +2086,6 @@ func init() {
           },
           "404": {
             "description": "Successful query result but no resource was found."
-          },
-          "501": {
-            "description": "Not (yet) implemented."
           }
         },
         "x-available-in-mqtt": false,
@@ -2170,9 +2137,6 @@ func init() {
             "schema": {
               "$ref": "#/definitions/ErrorResponse"
             }
-          },
-          "501": {
-            "description": "Not (yet) implemented."
           }
         },
         "x-available-in-mqtt": false,
@@ -2207,9 +2171,6 @@ func init() {
           },
           "404": {
             "description": "Successful query result but no resource was found."
-          },
-          "501": {
-            "description": "Not (yet) implemented."
           }
         },
         "x-available-in-mqtt": true,
@@ -2268,9 +2229,6 @@ func init() {
             "schema": {
               "$ref": "#/definitions/ErrorResponse"
             }
-          },
-          "501": {
-            "description": "Not (yet) implemented."
           }
         },
         "x-available-in-mqtt": false,
@@ -2356,9 +2314,6 @@ func init() {
             "schema": {
               "$ref": "#/definitions/ErrorResponse"
             }
-          },
-          "501": {
-            "description": "Not (yet) implemented."
           }
         },
         "x-available-in-mqtt": false,
@@ -2398,9 +2353,6 @@ func init() {
             "schema": {
               "$ref": "#/definitions/ErrorResponse"
             }
-          },
-          "501": {
-            "description": "Not (yet) implemented."
           }
         },
         "x-available-in-mqtt": false,
@@ -2427,9 +2379,6 @@ func init() {
           },
           "404": {
             "description": "Successful query result but no resource was found."
-          },
-          "501": {
-            "description": "Not (yet) implemented."
           }
         },
         "x-available-in-mqtt": false,
@@ -2456,9 +2405,6 @@ func init() {
           },
           "404": {
             "description": "Successful query result but no resource was found."
-          },
-          "501": {
-            "description": "Not (yet) implemented"
           }
         },
         "x-available-in-mqtt": false,
@@ -2498,9 +2444,6 @@ func init() {
           },
           "404": {
             "description": "Successful query result but no resource was found."
-          },
-          "501": {
-            "description": "Not (yet) implemented."
           }
         },
         "x-available-in-mqtt": false,
@@ -2535,9 +2478,6 @@ func init() {
           },
           "404": {
             "description": "Successful query result but no resource was found."
-          },
-          "501": {
-            "description": "Not (yet) implemented."
           }
         },
         "x-available-in-mqtt": false,
@@ -2577,9 +2517,6 @@ func init() {
           },
           "404": {
             "description": "Successful query result but no resource was found."
-          },
-          "501": {
-            "description": "Not (yet) implemented"
           }
         },
         "x-available-in-mqtt": false,
@@ -2625,9 +2562,6 @@ func init() {
             "schema": {
               "$ref": "#/definitions/ErrorResponse"
             }
-          },
-          "501": {
-            "description": "Not (yet) implemented."
           }
         },
         "x-available-in-mqtt": false,
@@ -2654,9 +2588,6 @@ func init() {
           },
           "401": {
             "description": "Unauthorized or invalid credentials."
-          },
-          "501": {
-            "description": "Not (yet) implemented"
           }
         },
         "x-available-in-mqtt": false,
@@ -2756,9 +2687,6 @@ func init() {
           },
           "404": {
             "description": "Successful query result but no resource was found."
-          },
-          "501": {
-            "description": "Not (yet) implemented."
           }
         },
         "x-available-in-mqtt": false,
@@ -2777,11 +2705,26 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/ThingCreate"
+              "type": "object",
+              "properties": {
+                "async": {
+                  "description": "If ` + "`" + `async` + "`" + ` is true, return a 202 with the new ID of the Thing. You will receive this response before the data is persisted. If ` + "`" + `async` + "`" + ` is false, you will receive confirmation after the value is persisted. The value of ` + "`" + `async` + "`" + ` defaults to false.",
+                  "type": "boolean"
+                },
+                "thing": {
+                  "$ref": "#/definitions/ThingCreate"
+                }
+              }
             }
           }
         ],
         "responses": {
+          "200": {
+            "description": "Thing created.",
+            "schema": {
+              "$ref": "#/definitions/ThingGetResponse"
+            }
+          },
           "202": {
             "description": "Successfully received.",
             "schema": {
@@ -2799,9 +2742,6 @@ func init() {
             "schema": {
               "$ref": "#/definitions/ErrorResponse"
             }
-          },
-          "501": {
-            "description": "Not (yet) implemented."
           }
         },
         "x-available-in-mqtt": false,
@@ -2841,9 +2781,6 @@ func init() {
             "schema": {
               "$ref": "#/definitions/ErrorResponse"
             }
-          },
-          "501": {
-            "description": "Not (yet) implemented."
           }
         },
         "x-available-in-mqtt": false,
@@ -2883,9 +2820,6 @@ func init() {
           },
           "404": {
             "description": "Successful query result but no resource was found."
-          },
-          "501": {
-            "description": "Not (yet) implemented."
           }
         },
         "x-available-in-mqtt": false,
@@ -2937,9 +2871,6 @@ func init() {
             "schema": {
               "$ref": "#/definitions/ErrorResponse"
             }
-          },
-          "501": {
-            "description": "Not (yet) implemented."
           }
         },
         "x-available-in-mqtt": false,
@@ -2974,9 +2905,6 @@ func init() {
           },
           "404": {
             "description": "Successful query result but no resource was found."
-          },
-          "501": {
-            "description": "Not (yet) implemented."
           }
         },
         "x-available-in-mqtt": true,
@@ -3035,9 +2963,6 @@ func init() {
             "schema": {
               "$ref": "#/definitions/ErrorResponse"
             }
-          },
-          "501": {
-            "description": "Not (yet) implemented."
           }
         },
         "x-available-in-mqtt": false,
@@ -3091,9 +3016,6 @@ func init() {
           },
           "404": {
             "description": "Successful query result but no resource was found."
-          },
-          "501": {
-            "description": "Not (yet) implemented."
           }
         },
         "x-available-in-mqtt": false,

--- a/restapi/operations/actions/weaviate_action_update_responses.go
+++ b/restapi/operations/actions/weaviate_action_update_responses.go
@@ -184,27 +184,3 @@ func (o *WeaviateActionUpdateUnprocessableEntity) WriteResponse(rw http.Response
 		}
 	}
 }
-
-// WeaviateActionUpdateNotImplementedCode is the HTTP code returned for type WeaviateActionUpdateNotImplemented
-const WeaviateActionUpdateNotImplementedCode int = 501
-
-/*WeaviateActionUpdateNotImplemented Not (yet) implemented.
-
-swagger:response weaviateActionUpdateNotImplemented
-*/
-type WeaviateActionUpdateNotImplemented struct {
-}
-
-// NewWeaviateActionUpdateNotImplemented creates WeaviateActionUpdateNotImplemented with default headers values
-func NewWeaviateActionUpdateNotImplemented() *WeaviateActionUpdateNotImplemented {
-
-	return &WeaviateActionUpdateNotImplemented{}
-}
-
-// WriteResponse to the client
-func (o *WeaviateActionUpdateNotImplemented) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
-
-	rw.Header().Del(runtime.HeaderContentType) //Remove Content-Type on empty responses
-
-	rw.WriteHeader(501)
-}

--- a/restapi/operations/actions/weaviate_actions_create.go
+++ b/restapi/operations/actions/weaviate_actions_create.go
@@ -20,7 +20,12 @@ package actions
 import (
 	"net/http"
 
+	errors "github.com/go-openapi/errors"
 	middleware "github.com/go-openapi/runtime/middleware"
+	strfmt "github.com/go-openapi/strfmt"
+	swag "github.com/go-openapi/swag"
+
+	models "github.com/creativesoftwarefdn/weaviate/models"
 )
 
 // WeaviateActionsCreateHandlerFunc turns a function with the right signature into a weaviate actions create handler
@@ -82,4 +87,65 @@ func (o *WeaviateActionsCreate) ServeHTTP(rw http.ResponseWriter, r *http.Reques
 
 	o.Context.Respond(rw, r, route.Produces, route, res)
 
+}
+
+// WeaviateActionsCreateBody weaviate actions create body
+// swagger:model WeaviateActionsCreateBody
+type WeaviateActionsCreateBody struct {
+
+	// action
+	Action *models.ActionCreate `json:"action,omitempty"`
+
+	// If `async` is true, return a 202 with the new ID of the Action. You will receive this response before the data is persisted. If `async` is false, you will receive confirmation after the value is persisted. The value of `async` defaults to false.
+	Async bool `json:"async,omitempty"`
+}
+
+// Validate validates this weaviate actions create body
+func (o *WeaviateActionsCreateBody) Validate(formats strfmt.Registry) error {
+	var res []error
+
+	if err := o.validateAction(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (o *WeaviateActionsCreateBody) validateAction(formats strfmt.Registry) error {
+
+	if swag.IsZero(o.Action) { // not required
+		return nil
+	}
+
+	if o.Action != nil {
+		if err := o.Action.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("body" + "." + "action")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+// MarshalBinary interface implementation
+func (o *WeaviateActionsCreateBody) MarshalBinary() ([]byte, error) {
+	if o == nil {
+		return nil, nil
+	}
+	return swag.WriteJSON(o)
+}
+
+// UnmarshalBinary interface implementation
+func (o *WeaviateActionsCreateBody) UnmarshalBinary(b []byte) error {
+	var res WeaviateActionsCreateBody
+	if err := swag.ReadJSON(b, &res); err != nil {
+		return err
+	}
+	*o = res
+	return nil
 }

--- a/restapi/operations/actions/weaviate_actions_create_parameters.go
+++ b/restapi/operations/actions/weaviate_actions_create_parameters.go
@@ -24,8 +24,6 @@ import (
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/runtime/middleware"
-
-	models "github.com/creativesoftwarefdn/weaviate/models"
 )
 
 // NewWeaviateActionsCreateParams creates a new WeaviateActionsCreateParams object
@@ -48,7 +46,7 @@ type WeaviateActionsCreateParams struct {
 	  Required: true
 	  In: body
 	*/
-	Body *models.ActionCreate
+	Body WeaviateActionsCreateBody
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -62,7 +60,7 @@ func (o *WeaviateActionsCreateParams) BindRequest(r *http.Request, route *middle
 
 	if runtime.HasBody(r) {
 		defer r.Body.Close()
-		var body models.ActionCreate
+		var body WeaviateActionsCreateBody
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
 				res = append(res, errors.Required("body", "body"))
@@ -76,7 +74,7 @@ func (o *WeaviateActionsCreateParams) BindRequest(r *http.Request, route *middle
 			}
 
 			if len(res) == 0 {
-				o.Body = &body
+				o.Body = body
 			}
 		}
 	} else {

--- a/restapi/operations/actions/weaviate_actions_create_responses.go
+++ b/restapi/operations/actions/weaviate_actions_create_responses.go
@@ -25,10 +25,54 @@ import (
 	models "github.com/creativesoftwarefdn/weaviate/models"
 )
 
+// WeaviateActionsCreateOKCode is the HTTP code returned for type WeaviateActionsCreateOK
+const WeaviateActionsCreateOKCode int = 200
+
+/*WeaviateActionsCreateOK Action created
+
+swagger:response weaviateActionsCreateOK
+*/
+type WeaviateActionsCreateOK struct {
+
+	/*
+	  In: Body
+	*/
+	Payload *models.ActionGetResponse `json:"body,omitempty"`
+}
+
+// NewWeaviateActionsCreateOK creates WeaviateActionsCreateOK with default headers values
+func NewWeaviateActionsCreateOK() *WeaviateActionsCreateOK {
+
+	return &WeaviateActionsCreateOK{}
+}
+
+// WithPayload adds the payload to the weaviate actions create o k response
+func (o *WeaviateActionsCreateOK) WithPayload(payload *models.ActionGetResponse) *WeaviateActionsCreateOK {
+	o.Payload = payload
+	return o
+}
+
+// SetPayload sets the payload to the weaviate actions create o k response
+func (o *WeaviateActionsCreateOK) SetPayload(payload *models.ActionGetResponse) {
+	o.Payload = payload
+}
+
+// WriteResponse to the client
+func (o *WeaviateActionsCreateOK) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.WriteHeader(200)
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
+	}
+}
+
 // WeaviateActionsCreateAcceptedCode is the HTTP code returned for type WeaviateActionsCreateAccepted
 const WeaviateActionsCreateAcceptedCode int = 202
 
-/*WeaviateActionsCreateAccepted Successfully received.
+/*WeaviateActionsCreateAccepted Successfully received. No guarantees are made that the Action is persisted.
 
 swagger:response weaviateActionsCreateAccepted
 */
@@ -159,28 +203,4 @@ func (o *WeaviateActionsCreateUnprocessableEntity) WriteResponse(rw http.Respons
 			panic(err) // let the recovery middleware deal with this
 		}
 	}
-}
-
-// WeaviateActionsCreateNotImplementedCode is the HTTP code returned for type WeaviateActionsCreateNotImplemented
-const WeaviateActionsCreateNotImplementedCode int = 501
-
-/*WeaviateActionsCreateNotImplemented Not (yet) implemented.
-
-swagger:response weaviateActionsCreateNotImplemented
-*/
-type WeaviateActionsCreateNotImplemented struct {
-}
-
-// NewWeaviateActionsCreateNotImplemented creates WeaviateActionsCreateNotImplemented with default headers values
-func NewWeaviateActionsCreateNotImplemented() *WeaviateActionsCreateNotImplemented {
-
-	return &WeaviateActionsCreateNotImplemented{}
-}
-
-// WriteResponse to the client
-func (o *WeaviateActionsCreateNotImplemented) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
-
-	rw.Header().Del(runtime.HeaderContentType) //Remove Content-Type on empty responses
-
-	rw.WriteHeader(501)
 }

--- a/restapi/operations/actions/weaviate_actions_delete_responses.go
+++ b/restapi/operations/actions/weaviate_actions_delete_responses.go
@@ -118,27 +118,3 @@ func (o *WeaviateActionsDeleteNotFound) WriteResponse(rw http.ResponseWriter, pr
 
 	rw.WriteHeader(404)
 }
-
-// WeaviateActionsDeleteNotImplementedCode is the HTTP code returned for type WeaviateActionsDeleteNotImplemented
-const WeaviateActionsDeleteNotImplementedCode int = 501
-
-/*WeaviateActionsDeleteNotImplemented Not (yet) implemented.
-
-swagger:response weaviateActionsDeleteNotImplemented
-*/
-type WeaviateActionsDeleteNotImplemented struct {
-}
-
-// NewWeaviateActionsDeleteNotImplemented creates WeaviateActionsDeleteNotImplemented with default headers values
-func NewWeaviateActionsDeleteNotImplemented() *WeaviateActionsDeleteNotImplemented {
-
-	return &WeaviateActionsDeleteNotImplemented{}
-}
-
-// WriteResponse to the client
-func (o *WeaviateActionsDeleteNotImplemented) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
-
-	rw.Header().Del(runtime.HeaderContentType) //Remove Content-Type on empty responses
-
-	rw.WriteHeader(501)
-}

--- a/restapi/operations/actions/weaviate_actions_get_responses.go
+++ b/restapi/operations/actions/weaviate_actions_get_responses.go
@@ -140,27 +140,3 @@ func (o *WeaviateActionsGetNotFound) WriteResponse(rw http.ResponseWriter, produ
 
 	rw.WriteHeader(404)
 }
-
-// WeaviateActionsGetNotImplementedCode is the HTTP code returned for type WeaviateActionsGetNotImplemented
-const WeaviateActionsGetNotImplementedCode int = 501
-
-/*WeaviateActionsGetNotImplemented Not (yet) implemented.
-
-swagger:response weaviateActionsGetNotImplemented
-*/
-type WeaviateActionsGetNotImplemented struct {
-}
-
-// NewWeaviateActionsGetNotImplemented creates WeaviateActionsGetNotImplemented with default headers values
-func NewWeaviateActionsGetNotImplemented() *WeaviateActionsGetNotImplemented {
-
-	return &WeaviateActionsGetNotImplemented{}
-}
-
-// WriteResponse to the client
-func (o *WeaviateActionsGetNotImplemented) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
-
-	rw.Header().Del(runtime.HeaderContentType) //Remove Content-Type on empty responses
-
-	rw.WriteHeader(501)
-}

--- a/restapi/operations/actions/weaviate_actions_patch_responses.go
+++ b/restapi/operations/actions/weaviate_actions_patch_responses.go
@@ -208,27 +208,3 @@ func (o *WeaviateActionsPatchUnprocessableEntity) WriteResponse(rw http.Response
 		}
 	}
 }
-
-// WeaviateActionsPatchNotImplementedCode is the HTTP code returned for type WeaviateActionsPatchNotImplemented
-const WeaviateActionsPatchNotImplementedCode int = 501
-
-/*WeaviateActionsPatchNotImplemented Not (yet) implemented.
-
-swagger:response weaviateActionsPatchNotImplemented
-*/
-type WeaviateActionsPatchNotImplemented struct {
-}
-
-// NewWeaviateActionsPatchNotImplemented creates WeaviateActionsPatchNotImplemented with default headers values
-func NewWeaviateActionsPatchNotImplemented() *WeaviateActionsPatchNotImplemented {
-
-	return &WeaviateActionsPatchNotImplemented{}
-}
-
-// WriteResponse to the client
-func (o *WeaviateActionsPatchNotImplemented) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
-
-	rw.Header().Del(runtime.HeaderContentType) //Remove Content-Type on empty responses
-
-	rw.WriteHeader(501)
-}

--- a/restapi/operations/actions/weaviate_actions_validate_responses.go
+++ b/restapi/operations/actions/weaviate_actions_validate_responses.go
@@ -140,27 +140,3 @@ func (o *WeaviateActionsValidateUnprocessableEntity) WriteResponse(rw http.Respo
 		}
 	}
 }
-
-// WeaviateActionsValidateNotImplementedCode is the HTTP code returned for type WeaviateActionsValidateNotImplemented
-const WeaviateActionsValidateNotImplementedCode int = 501
-
-/*WeaviateActionsValidateNotImplemented Not (yet) implemented.
-
-swagger:response weaviateActionsValidateNotImplemented
-*/
-type WeaviateActionsValidateNotImplemented struct {
-}
-
-// NewWeaviateActionsValidateNotImplemented creates WeaviateActionsValidateNotImplemented with default headers values
-func NewWeaviateActionsValidateNotImplemented() *WeaviateActionsValidateNotImplemented {
-
-	return &WeaviateActionsValidateNotImplemented{}
-}
-
-// WriteResponse to the client
-func (o *WeaviateActionsValidateNotImplemented) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
-
-	rw.Header().Del(runtime.HeaderContentType) //Remove Content-Type on empty responses
-
-	rw.WriteHeader(501)
-}

--- a/restapi/operations/graphql/weaviate_graphql_post_responses.go
+++ b/restapi/operations/graphql/weaviate_graphql_post_responses.go
@@ -160,27 +160,3 @@ func (o *WeaviateGraphqlPostUnprocessableEntity) WriteResponse(rw http.ResponseW
 		}
 	}
 }
-
-// WeaviateGraphqlPostNotImplementedCode is the HTTP code returned for type WeaviateGraphqlPostNotImplemented
-const WeaviateGraphqlPostNotImplementedCode int = 501
-
-/*WeaviateGraphqlPostNotImplemented Not (yet) implemented.
-
-swagger:response weaviateGraphqlPostNotImplemented
-*/
-type WeaviateGraphqlPostNotImplemented struct {
-}
-
-// NewWeaviateGraphqlPostNotImplemented creates WeaviateGraphqlPostNotImplemented with default headers values
-func NewWeaviateGraphqlPostNotImplemented() *WeaviateGraphqlPostNotImplemented {
-
-	return &WeaviateGraphqlPostNotImplemented{}
-}
-
-// WriteResponse to the client
-func (o *WeaviateGraphqlPostNotImplemented) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
-
-	rw.Header().Del(runtime.HeaderContentType) //Remove Content-Type on empty responses
-
-	rw.WriteHeader(501)
-}

--- a/restapi/operations/keys/weaviate_key_create_responses.go
+++ b/restapi/operations/keys/weaviate_key_create_responses.go
@@ -136,27 +136,3 @@ func (o *WeaviateKeyCreateUnprocessableEntity) WriteResponse(rw http.ResponseWri
 		}
 	}
 }
-
-// WeaviateKeyCreateNotImplementedCode is the HTTP code returned for type WeaviateKeyCreateNotImplemented
-const WeaviateKeyCreateNotImplementedCode int = 501
-
-/*WeaviateKeyCreateNotImplemented Not (yet) implemented.
-
-swagger:response weaviateKeyCreateNotImplemented
-*/
-type WeaviateKeyCreateNotImplemented struct {
-}
-
-// NewWeaviateKeyCreateNotImplemented creates WeaviateKeyCreateNotImplemented with default headers values
-func NewWeaviateKeyCreateNotImplemented() *WeaviateKeyCreateNotImplemented {
-
-	return &WeaviateKeyCreateNotImplemented{}
-}
-
-// WriteResponse to the client
-func (o *WeaviateKeyCreateNotImplemented) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
-
-	rw.Header().Del(runtime.HeaderContentType) //Remove Content-Type on empty responses
-
-	rw.WriteHeader(501)
-}

--- a/restapi/operations/keys/weaviate_keys_children_get_responses.go
+++ b/restapi/operations/keys/weaviate_keys_children_get_responses.go
@@ -140,27 +140,3 @@ func (o *WeaviateKeysChildrenGetNotFound) WriteResponse(rw http.ResponseWriter, 
 
 	rw.WriteHeader(404)
 }
-
-// WeaviateKeysChildrenGetNotImplementedCode is the HTTP code returned for type WeaviateKeysChildrenGetNotImplemented
-const WeaviateKeysChildrenGetNotImplementedCode int = 501
-
-/*WeaviateKeysChildrenGetNotImplemented Not (yet) implemented
-
-swagger:response weaviateKeysChildrenGetNotImplemented
-*/
-type WeaviateKeysChildrenGetNotImplemented struct {
-}
-
-// NewWeaviateKeysChildrenGetNotImplemented creates WeaviateKeysChildrenGetNotImplemented with default headers values
-func NewWeaviateKeysChildrenGetNotImplemented() *WeaviateKeysChildrenGetNotImplemented {
-
-	return &WeaviateKeysChildrenGetNotImplemented{}
-}
-
-// WriteResponse to the client
-func (o *WeaviateKeysChildrenGetNotImplemented) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
-
-	rw.Header().Del(runtime.HeaderContentType) //Remove Content-Type on empty responses
-
-	rw.WriteHeader(501)
-}

--- a/restapi/operations/keys/weaviate_keys_delete_responses.go
+++ b/restapi/operations/keys/weaviate_keys_delete_responses.go
@@ -118,27 +118,3 @@ func (o *WeaviateKeysDeleteNotFound) WriteResponse(rw http.ResponseWriter, produ
 
 	rw.WriteHeader(404)
 }
-
-// WeaviateKeysDeleteNotImplementedCode is the HTTP code returned for type WeaviateKeysDeleteNotImplemented
-const WeaviateKeysDeleteNotImplementedCode int = 501
-
-/*WeaviateKeysDeleteNotImplemented Not (yet) implemented.
-
-swagger:response weaviateKeysDeleteNotImplemented
-*/
-type WeaviateKeysDeleteNotImplemented struct {
-}
-
-// NewWeaviateKeysDeleteNotImplemented creates WeaviateKeysDeleteNotImplemented with default headers values
-func NewWeaviateKeysDeleteNotImplemented() *WeaviateKeysDeleteNotImplemented {
-
-	return &WeaviateKeysDeleteNotImplemented{}
-}
-
-// WriteResponse to the client
-func (o *WeaviateKeysDeleteNotImplemented) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
-
-	rw.Header().Del(runtime.HeaderContentType) //Remove Content-Type on empty responses
-
-	rw.WriteHeader(501)
-}

--- a/restapi/operations/keys/weaviate_keys_get_responses.go
+++ b/restapi/operations/keys/weaviate_keys_get_responses.go
@@ -140,27 +140,3 @@ func (o *WeaviateKeysGetNotFound) WriteResponse(rw http.ResponseWriter, producer
 
 	rw.WriteHeader(404)
 }
-
-// WeaviateKeysGetNotImplementedCode is the HTTP code returned for type WeaviateKeysGetNotImplemented
-const WeaviateKeysGetNotImplementedCode int = 501
-
-/*WeaviateKeysGetNotImplemented Not (yet) implemented.
-
-swagger:response weaviateKeysGetNotImplemented
-*/
-type WeaviateKeysGetNotImplemented struct {
-}
-
-// NewWeaviateKeysGetNotImplemented creates WeaviateKeysGetNotImplemented with default headers values
-func NewWeaviateKeysGetNotImplemented() *WeaviateKeysGetNotImplemented {
-
-	return &WeaviateKeysGetNotImplemented{}
-}
-
-// WriteResponse to the client
-func (o *WeaviateKeysGetNotImplemented) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
-
-	rw.Header().Del(runtime.HeaderContentType) //Remove Content-Type on empty responses
-
-	rw.WriteHeader(501)
-}

--- a/restapi/operations/keys/weaviate_keys_me_children_get_responses.go
+++ b/restapi/operations/keys/weaviate_keys_me_children_get_responses.go
@@ -116,27 +116,3 @@ func (o *WeaviateKeysMeChildrenGetNotFound) WriteResponse(rw http.ResponseWriter
 
 	rw.WriteHeader(404)
 }
-
-// WeaviateKeysMeChildrenGetNotImplementedCode is the HTTP code returned for type WeaviateKeysMeChildrenGetNotImplemented
-const WeaviateKeysMeChildrenGetNotImplementedCode int = 501
-
-/*WeaviateKeysMeChildrenGetNotImplemented Not (yet) implemented
-
-swagger:response weaviateKeysMeChildrenGetNotImplemented
-*/
-type WeaviateKeysMeChildrenGetNotImplemented struct {
-}
-
-// NewWeaviateKeysMeChildrenGetNotImplemented creates WeaviateKeysMeChildrenGetNotImplemented with default headers values
-func NewWeaviateKeysMeChildrenGetNotImplemented() *WeaviateKeysMeChildrenGetNotImplemented {
-
-	return &WeaviateKeysMeChildrenGetNotImplemented{}
-}
-
-// WriteResponse to the client
-func (o *WeaviateKeysMeChildrenGetNotImplemented) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
-
-	rw.Header().Del(runtime.HeaderContentType) //Remove Content-Type on empty responses
-
-	rw.WriteHeader(501)
-}

--- a/restapi/operations/keys/weaviate_keys_me_get_responses.go
+++ b/restapi/operations/keys/weaviate_keys_me_get_responses.go
@@ -116,27 +116,3 @@ func (o *WeaviateKeysMeGetNotFound) WriteResponse(rw http.ResponseWriter, produc
 
 	rw.WriteHeader(404)
 }
-
-// WeaviateKeysMeGetNotImplementedCode is the HTTP code returned for type WeaviateKeysMeGetNotImplemented
-const WeaviateKeysMeGetNotImplementedCode int = 501
-
-/*WeaviateKeysMeGetNotImplemented Not (yet) implemented.
-
-swagger:response weaviateKeysMeGetNotImplemented
-*/
-type WeaviateKeysMeGetNotImplemented struct {
-}
-
-// NewWeaviateKeysMeGetNotImplemented creates WeaviateKeysMeGetNotImplemented with default headers values
-func NewWeaviateKeysMeGetNotImplemented() *WeaviateKeysMeGetNotImplemented {
-
-	return &WeaviateKeysMeGetNotImplemented{}
-}
-
-// WriteResponse to the client
-func (o *WeaviateKeysMeGetNotImplemented) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
-
-	rw.Header().Del(runtime.HeaderContentType) //Remove Content-Type on empty responses
-
-	rw.WriteHeader(501)
-}

--- a/restapi/operations/keys/weaviate_keys_renew_token_responses.go
+++ b/restapi/operations/keys/weaviate_keys_renew_token_responses.go
@@ -184,27 +184,3 @@ func (o *WeaviateKeysRenewTokenUnprocessableEntity) WriteResponse(rw http.Respon
 		}
 	}
 }
-
-// WeaviateKeysRenewTokenNotImplementedCode is the HTTP code returned for type WeaviateKeysRenewTokenNotImplemented
-const WeaviateKeysRenewTokenNotImplementedCode int = 501
-
-/*WeaviateKeysRenewTokenNotImplemented Not (yet) implemented.
-
-swagger:response weaviateKeysRenewTokenNotImplemented
-*/
-type WeaviateKeysRenewTokenNotImplemented struct {
-}
-
-// NewWeaviateKeysRenewTokenNotImplemented creates WeaviateKeysRenewTokenNotImplemented with default headers values
-func NewWeaviateKeysRenewTokenNotImplemented() *WeaviateKeysRenewTokenNotImplemented {
-
-	return &WeaviateKeysRenewTokenNotImplemented{}
-}
-
-// WriteResponse to the client
-func (o *WeaviateKeysRenewTokenNotImplemented) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
-
-	rw.Header().Del(runtime.HeaderContentType) //Remove Content-Type on empty responses
-
-	rw.WriteHeader(501)
-}

--- a/restapi/operations/meta/weaviate_meta_get_responses.go
+++ b/restapi/operations/meta/weaviate_meta_get_responses.go
@@ -92,27 +92,3 @@ func (o *WeaviateMetaGetUnauthorized) WriteResponse(rw http.ResponseWriter, prod
 
 	rw.WriteHeader(401)
 }
-
-// WeaviateMetaGetNotImplementedCode is the HTTP code returned for type WeaviateMetaGetNotImplemented
-const WeaviateMetaGetNotImplementedCode int = 501
-
-/*WeaviateMetaGetNotImplemented Not (yet) implemented
-
-swagger:response weaviateMetaGetNotImplemented
-*/
-type WeaviateMetaGetNotImplemented struct {
-}
-
-// NewWeaviateMetaGetNotImplemented creates WeaviateMetaGetNotImplemented with default headers values
-func NewWeaviateMetaGetNotImplemented() *WeaviateMetaGetNotImplemented {
-
-	return &WeaviateMetaGetNotImplemented{}
-}
-
-// WriteResponse to the client
-func (o *WeaviateMetaGetNotImplemented) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
-
-	rw.Header().Del(runtime.HeaderContentType) //Remove Content-Type on empty responses
-
-	rw.WriteHeader(501)
-}

--- a/restapi/operations/things/weaviate_things_actions_list_responses.go
+++ b/restapi/operations/things/weaviate_things_actions_list_responses.go
@@ -140,27 +140,3 @@ func (o *WeaviateThingsActionsListNotFound) WriteResponse(rw http.ResponseWriter
 
 	rw.WriteHeader(404)
 }
-
-// WeaviateThingsActionsListNotImplementedCode is the HTTP code returned for type WeaviateThingsActionsListNotImplemented
-const WeaviateThingsActionsListNotImplementedCode int = 501
-
-/*WeaviateThingsActionsListNotImplemented Not (yet) implemented.
-
-swagger:response weaviateThingsActionsListNotImplemented
-*/
-type WeaviateThingsActionsListNotImplemented struct {
-}
-
-// NewWeaviateThingsActionsListNotImplemented creates WeaviateThingsActionsListNotImplemented with default headers values
-func NewWeaviateThingsActionsListNotImplemented() *WeaviateThingsActionsListNotImplemented {
-
-	return &WeaviateThingsActionsListNotImplemented{}
-}
-
-// WriteResponse to the client
-func (o *WeaviateThingsActionsListNotImplemented) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
-
-	rw.Header().Del(runtime.HeaderContentType) //Remove Content-Type on empty responses
-
-	rw.WriteHeader(501)
-}

--- a/restapi/operations/things/weaviate_things_create.go
+++ b/restapi/operations/things/weaviate_things_create.go
@@ -20,7 +20,12 @@ package things
 import (
 	"net/http"
 
+	errors "github.com/go-openapi/errors"
 	middleware "github.com/go-openapi/runtime/middleware"
+	strfmt "github.com/go-openapi/strfmt"
+	swag "github.com/go-openapi/swag"
+
+	models "github.com/creativesoftwarefdn/weaviate/models"
 )
 
 // WeaviateThingsCreateHandlerFunc turns a function with the right signature into a weaviate things create handler
@@ -82,4 +87,65 @@ func (o *WeaviateThingsCreate) ServeHTTP(rw http.ResponseWriter, r *http.Request
 
 	o.Context.Respond(rw, r, route.Produces, route, res)
 
+}
+
+// WeaviateThingsCreateBody weaviate things create body
+// swagger:model WeaviateThingsCreateBody
+type WeaviateThingsCreateBody struct {
+
+	// If `async` is true, return a 202 with the new ID of the Thing. You will receive this response before the data is persisted. If `async` is false, you will receive confirmation after the value is persisted. The value of `async` defaults to false.
+	Async bool `json:"async,omitempty"`
+
+	// thing
+	Thing *models.ThingCreate `json:"thing,omitempty"`
+}
+
+// Validate validates this weaviate things create body
+func (o *WeaviateThingsCreateBody) Validate(formats strfmt.Registry) error {
+	var res []error
+
+	if err := o.validateThing(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (o *WeaviateThingsCreateBody) validateThing(formats strfmt.Registry) error {
+
+	if swag.IsZero(o.Thing) { // not required
+		return nil
+	}
+
+	if o.Thing != nil {
+		if err := o.Thing.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("body" + "." + "thing")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+// MarshalBinary interface implementation
+func (o *WeaviateThingsCreateBody) MarshalBinary() ([]byte, error) {
+	if o == nil {
+		return nil, nil
+	}
+	return swag.WriteJSON(o)
+}
+
+// UnmarshalBinary interface implementation
+func (o *WeaviateThingsCreateBody) UnmarshalBinary(b []byte) error {
+	var res WeaviateThingsCreateBody
+	if err := swag.ReadJSON(b, &res); err != nil {
+		return err
+	}
+	*o = res
+	return nil
 }

--- a/restapi/operations/things/weaviate_things_create_parameters.go
+++ b/restapi/operations/things/weaviate_things_create_parameters.go
@@ -24,8 +24,6 @@ import (
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/runtime/middleware"
-
-	models "github.com/creativesoftwarefdn/weaviate/models"
 )
 
 // NewWeaviateThingsCreateParams creates a new WeaviateThingsCreateParams object
@@ -48,7 +46,7 @@ type WeaviateThingsCreateParams struct {
 	  Required: true
 	  In: body
 	*/
-	Body *models.ThingCreate
+	Body WeaviateThingsCreateBody
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -62,7 +60,7 @@ func (o *WeaviateThingsCreateParams) BindRequest(r *http.Request, route *middlew
 
 	if runtime.HasBody(r) {
 		defer r.Body.Close()
-		var body models.ThingCreate
+		var body WeaviateThingsCreateBody
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
 				res = append(res, errors.Required("body", "body"))
@@ -76,7 +74,7 @@ func (o *WeaviateThingsCreateParams) BindRequest(r *http.Request, route *middlew
 			}
 
 			if len(res) == 0 {
-				o.Body = &body
+				o.Body = body
 			}
 		}
 	} else {

--- a/restapi/operations/things/weaviate_things_create_responses.go
+++ b/restapi/operations/things/weaviate_things_create_responses.go
@@ -25,6 +25,50 @@ import (
 	models "github.com/creativesoftwarefdn/weaviate/models"
 )
 
+// WeaviateThingsCreateOKCode is the HTTP code returned for type WeaviateThingsCreateOK
+const WeaviateThingsCreateOKCode int = 200
+
+/*WeaviateThingsCreateOK Thing created.
+
+swagger:response weaviateThingsCreateOK
+*/
+type WeaviateThingsCreateOK struct {
+
+	/*
+	  In: Body
+	*/
+	Payload *models.ThingGetResponse `json:"body,omitempty"`
+}
+
+// NewWeaviateThingsCreateOK creates WeaviateThingsCreateOK with default headers values
+func NewWeaviateThingsCreateOK() *WeaviateThingsCreateOK {
+
+	return &WeaviateThingsCreateOK{}
+}
+
+// WithPayload adds the payload to the weaviate things create o k response
+func (o *WeaviateThingsCreateOK) WithPayload(payload *models.ThingGetResponse) *WeaviateThingsCreateOK {
+	o.Payload = payload
+	return o
+}
+
+// SetPayload sets the payload to the weaviate things create o k response
+func (o *WeaviateThingsCreateOK) SetPayload(payload *models.ThingGetResponse) {
+	o.Payload = payload
+}
+
+// WriteResponse to the client
+func (o *WeaviateThingsCreateOK) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.WriteHeader(200)
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
+	}
+}
+
 // WeaviateThingsCreateAcceptedCode is the HTTP code returned for type WeaviateThingsCreateAccepted
 const WeaviateThingsCreateAcceptedCode int = 202
 
@@ -159,28 +203,4 @@ func (o *WeaviateThingsCreateUnprocessableEntity) WriteResponse(rw http.Response
 			panic(err) // let the recovery middleware deal with this
 		}
 	}
-}
-
-// WeaviateThingsCreateNotImplementedCode is the HTTP code returned for type WeaviateThingsCreateNotImplemented
-const WeaviateThingsCreateNotImplementedCode int = 501
-
-/*WeaviateThingsCreateNotImplemented Not (yet) implemented.
-
-swagger:response weaviateThingsCreateNotImplemented
-*/
-type WeaviateThingsCreateNotImplemented struct {
-}
-
-// NewWeaviateThingsCreateNotImplemented creates WeaviateThingsCreateNotImplemented with default headers values
-func NewWeaviateThingsCreateNotImplemented() *WeaviateThingsCreateNotImplemented {
-
-	return &WeaviateThingsCreateNotImplemented{}
-}
-
-// WriteResponse to the client
-func (o *WeaviateThingsCreateNotImplemented) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
-
-	rw.Header().Del(runtime.HeaderContentType) //Remove Content-Type on empty responses
-
-	rw.WriteHeader(501)
 }

--- a/restapi/operations/things/weaviate_things_delete_responses.go
+++ b/restapi/operations/things/weaviate_things_delete_responses.go
@@ -118,27 +118,3 @@ func (o *WeaviateThingsDeleteNotFound) WriteResponse(rw http.ResponseWriter, pro
 
 	rw.WriteHeader(404)
 }
-
-// WeaviateThingsDeleteNotImplementedCode is the HTTP code returned for type WeaviateThingsDeleteNotImplemented
-const WeaviateThingsDeleteNotImplementedCode int = 501
-
-/*WeaviateThingsDeleteNotImplemented Not (yet) implemented.
-
-swagger:response weaviateThingsDeleteNotImplemented
-*/
-type WeaviateThingsDeleteNotImplemented struct {
-}
-
-// NewWeaviateThingsDeleteNotImplemented creates WeaviateThingsDeleteNotImplemented with default headers values
-func NewWeaviateThingsDeleteNotImplemented() *WeaviateThingsDeleteNotImplemented {
-
-	return &WeaviateThingsDeleteNotImplemented{}
-}
-
-// WriteResponse to the client
-func (o *WeaviateThingsDeleteNotImplemented) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
-
-	rw.Header().Del(runtime.HeaderContentType) //Remove Content-Type on empty responses
-
-	rw.WriteHeader(501)
-}

--- a/restapi/operations/things/weaviate_things_get_responses.go
+++ b/restapi/operations/things/weaviate_things_get_responses.go
@@ -140,27 +140,3 @@ func (o *WeaviateThingsGetNotFound) WriteResponse(rw http.ResponseWriter, produc
 
 	rw.WriteHeader(404)
 }
-
-// WeaviateThingsGetNotImplementedCode is the HTTP code returned for type WeaviateThingsGetNotImplemented
-const WeaviateThingsGetNotImplementedCode int = 501
-
-/*WeaviateThingsGetNotImplemented Not (yet) implemented.
-
-swagger:response weaviateThingsGetNotImplemented
-*/
-type WeaviateThingsGetNotImplemented struct {
-}
-
-// NewWeaviateThingsGetNotImplemented creates WeaviateThingsGetNotImplemented with default headers values
-func NewWeaviateThingsGetNotImplemented() *WeaviateThingsGetNotImplemented {
-
-	return &WeaviateThingsGetNotImplemented{}
-}
-
-// WriteResponse to the client
-func (o *WeaviateThingsGetNotImplemented) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
-
-	rw.Header().Del(runtime.HeaderContentType) //Remove Content-Type on empty responses
-
-	rw.WriteHeader(501)
-}

--- a/restapi/operations/things/weaviate_things_list_responses.go
+++ b/restapi/operations/things/weaviate_things_list_responses.go
@@ -140,27 +140,3 @@ func (o *WeaviateThingsListNotFound) WriteResponse(rw http.ResponseWriter, produ
 
 	rw.WriteHeader(404)
 }
-
-// WeaviateThingsListNotImplementedCode is the HTTP code returned for type WeaviateThingsListNotImplemented
-const WeaviateThingsListNotImplementedCode int = 501
-
-/*WeaviateThingsListNotImplemented Not (yet) implemented.
-
-swagger:response weaviateThingsListNotImplemented
-*/
-type WeaviateThingsListNotImplemented struct {
-}
-
-// NewWeaviateThingsListNotImplemented creates WeaviateThingsListNotImplemented with default headers values
-func NewWeaviateThingsListNotImplemented() *WeaviateThingsListNotImplemented {
-
-	return &WeaviateThingsListNotImplemented{}
-}
-
-// WriteResponse to the client
-func (o *WeaviateThingsListNotImplemented) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
-
-	rw.Header().Del(runtime.HeaderContentType) //Remove Content-Type on empty responses
-
-	rw.WriteHeader(501)
-}

--- a/restapi/operations/things/weaviate_things_patch_responses.go
+++ b/restapi/operations/things/weaviate_things_patch_responses.go
@@ -208,27 +208,3 @@ func (o *WeaviateThingsPatchUnprocessableEntity) WriteResponse(rw http.ResponseW
 		}
 	}
 }
-
-// WeaviateThingsPatchNotImplementedCode is the HTTP code returned for type WeaviateThingsPatchNotImplemented
-const WeaviateThingsPatchNotImplementedCode int = 501
-
-/*WeaviateThingsPatchNotImplemented Not (yet) implemented.
-
-swagger:response weaviateThingsPatchNotImplemented
-*/
-type WeaviateThingsPatchNotImplemented struct {
-}
-
-// NewWeaviateThingsPatchNotImplemented creates WeaviateThingsPatchNotImplemented with default headers values
-func NewWeaviateThingsPatchNotImplemented() *WeaviateThingsPatchNotImplemented {
-
-	return &WeaviateThingsPatchNotImplemented{}
-}
-
-// WriteResponse to the client
-func (o *WeaviateThingsPatchNotImplemented) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
-
-	rw.Header().Del(runtime.HeaderContentType) //Remove Content-Type on empty responses
-
-	rw.WriteHeader(501)
-}

--- a/restapi/operations/things/weaviate_things_update_responses.go
+++ b/restapi/operations/things/weaviate_things_update_responses.go
@@ -184,27 +184,3 @@ func (o *WeaviateThingsUpdateUnprocessableEntity) WriteResponse(rw http.Response
 		}
 	}
 }
-
-// WeaviateThingsUpdateNotImplementedCode is the HTTP code returned for type WeaviateThingsUpdateNotImplemented
-const WeaviateThingsUpdateNotImplementedCode int = 501
-
-/*WeaviateThingsUpdateNotImplemented Not (yet) implemented.
-
-swagger:response weaviateThingsUpdateNotImplemented
-*/
-type WeaviateThingsUpdateNotImplemented struct {
-}
-
-// NewWeaviateThingsUpdateNotImplemented creates WeaviateThingsUpdateNotImplemented with default headers values
-func NewWeaviateThingsUpdateNotImplemented() *WeaviateThingsUpdateNotImplemented {
-
-	return &WeaviateThingsUpdateNotImplemented{}
-}
-
-// WriteResponse to the client
-func (o *WeaviateThingsUpdateNotImplemented) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
-
-	rw.Header().Del(runtime.HeaderContentType) //Remove Content-Type on empty responses
-
-	rw.WriteHeader(501)
-}

--- a/restapi/operations/things/weaviate_things_validate_responses.go
+++ b/restapi/operations/things/weaviate_things_validate_responses.go
@@ -140,27 +140,3 @@ func (o *WeaviateThingsValidateUnprocessableEntity) WriteResponse(rw http.Respon
 		}
 	}
 }
-
-// WeaviateThingsValidateNotImplementedCode is the HTTP code returned for type WeaviateThingsValidateNotImplemented
-const WeaviateThingsValidateNotImplementedCode int = 501
-
-/*WeaviateThingsValidateNotImplemented Not (yet) implemented.
-
-swagger:response weaviateThingsValidateNotImplemented
-*/
-type WeaviateThingsValidateNotImplemented struct {
-}
-
-// NewWeaviateThingsValidateNotImplemented creates WeaviateThingsValidateNotImplemented with default headers values
-func NewWeaviateThingsValidateNotImplemented() *WeaviateThingsValidateNotImplemented {
-
-	return &WeaviateThingsValidateNotImplemented{}
-}
-
-// WriteResponse to the client
-func (o *WeaviateThingsValidateNotImplemented) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
-
-	rw.Header().Del(runtime.HeaderContentType) //Remove Content-Type on empty responses
-
-	rw.WriteHeader(501)
-}


### PR DESCRIPTION
The changes as discussed last Thursday.

- Add an async parameter
- Move the ThingCreate/ActionCreate respectively under a  "thing" and "action" object.

As a bonus, I've thrown in the unused 501's as well. (Note that I kept the 501's for the History endpoints).