### PR TITLE
gh-488 re-add ResolveType function for dataTypeUnionConf

### DIFF
--- a/graphqlapi/dynamic_generation_get.go
+++ b/graphqlapi/dynamic_generation_get.go
@@ -107,8 +107,11 @@ func genSingleActionClassPropertyFields(class *models.SemanticSchemaClass, getAc
 			}
 
 			dataTypeUnionConf := graphql.UnionConfig{
-				Name:        fmt.Sprintf("%s%s%s", class.Class, capitalizedPropertyName, "Obj"),
-				Types:       dataTypeClasses,
+				Name:  fmt.Sprintf("%s%s%s", class.Class, capitalizedPropertyName, "Obj"),
+				Types: dataTypeClasses,
+				ResolveType: func(p graphql.ResolveTypeParams) *graphql.Object {
+					return nil
+				},
 				Description: property.Description,
 			}
 


### PR DESCRIPTION
fixes #488 

The commit 7e65baa removed this particular resolver, this leads to the
dev-setup not working anymore. Weaviate is exiting with exit code one
and the error:

```
2018/09/22 13:02:28 ERROR: GraphQL schema initialization gave an error when initializing: could not build GraphQL schema, because: Union Type FlightAircraftObj does not provide a "resolveType" function and possible Type Aircraft does not provide a "isTypeOf" function. There is no way to resolve this possible type during execution..
```

This commit simply re-adds this one single resolver, so that we have a
working dev-setup again.

If the removal was intended, we probably need to replace it rather than
just removing it. For now I'm assuming the removal was accidental.