### PR TITLE
gh-521: Add Error array

### DIFF
--- a/models/error_response.go
+++ b/models/error_response.go
@@ -18,6 +18,8 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"strconv"
+
 	strfmt "github.com/go-openapi/strfmt"
 
 	"github.com/go-openapi/errors"
@@ -29,7 +31,7 @@ import (
 type ErrorResponse struct {
 
 	// error
-	Error *ErrorResponseError `json:"error,omitempty"`
+	Error []*ErrorResponseErrorItems0 `json:"error"`
 }
 
 // Validate validates this error response
@@ -52,13 +54,20 @@ func (m *ErrorResponse) validateError(formats strfmt.Registry) error {
 		return nil
 	}
 
-	if m.Error != nil {
-		if err := m.Error.Validate(formats); err != nil {
-			if ve, ok := err.(*errors.Validation); ok {
-				return ve.ValidateName("error")
-			}
-			return err
+	for i := 0; i < len(m.Error); i++ {
+		if swag.IsZero(m.Error[i]) { // not required
+			continue
 		}
+
+		if m.Error[i] != nil {
+			if err := m.Error[i].Validate(formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("error" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
 	}
 
 	return nil
@@ -82,21 +91,21 @@ func (m *ErrorResponse) UnmarshalBinary(b []byte) error {
 	return nil
 }
 
-// ErrorResponseError error response error
-// swagger:model ErrorResponseError
-type ErrorResponseError struct {
+// ErrorResponseErrorItems0 error response error items0
+// swagger:model ErrorResponseErrorItems0
+type ErrorResponseErrorItems0 struct {
 
 	// message
 	Message string `json:"message,omitempty"`
 }
 
-// Validate validates this error response error
-func (m *ErrorResponseError) Validate(formats strfmt.Registry) error {
+// Validate validates this error response error items0
+func (m *ErrorResponseErrorItems0) Validate(formats strfmt.Registry) error {
 	return nil
 }
 
 // MarshalBinary interface implementation
-func (m *ErrorResponseError) MarshalBinary() ([]byte, error) {
+func (m *ErrorResponseErrorItems0) MarshalBinary() ([]byte, error) {
 	if m == nil {
 		return nil, nil
 	}
@@ -104,8 +113,8 @@ func (m *ErrorResponseError) MarshalBinary() ([]byte, error) {
 }
 
 // UnmarshalBinary interface implementation
-func (m *ErrorResponseError) UnmarshalBinary(b []byte) error {
-	var res ErrorResponseError
+func (m *ErrorResponseErrorItems0) UnmarshalBinary(b []byte) error {
+	var res ErrorResponseErrorItems0
 	if err := swag.ReadJSON(b, &res); err != nil {
 		return err
 	}

--- a/openapi-specs/schema.json
+++ b/openapi-specs/schema.json
@@ -155,14 +155,17 @@
       "description": "An error response given by Weaviate end-points.",
       "properties": {
         "error": {
-          "properties": {
-            "message": {
-              "type": "string"
-            }
-          },
-          "type": "object"
-        }
-      },
+          "items": {
+            "properties": {
+              "message": {
+                "type": "string"
+              }    
+            },   
+            "type": "object"
+          },   
+          "type": "array"
+        }    
+      },   
       "type": "object"
     },
     "GraphQLError": {

--- a/restapi/configure_weaviate.go
+++ b/restapi/configure_weaviate.go
@@ -195,13 +195,15 @@ func configureFlags(api *operations.WeaviateAPI) {
 }
 
 // createErrorResponseObject is a common function to create an error response
-func createErrorResponseObject(message string) *models.ErrorResponse {
+func createErrorResponseObject(messages ...string) *models.ErrorResponse {
 	// Initialize return value
 	er := &models.ErrorResponse{}
 
-	// Fill the error with the message
-	er.Error = &models.ErrorResponseError{
-		Message: message,
+	// appends all error messages to the error
+	for _, message := range messages {
+		er.Error = append(er.Error, &models.ErrorResponseErrorItems0{
+			Message: message,
+		})
 	}
 
 	return er

--- a/restapi/configure_weaviate_test.go
+++ b/restapi/configure_weaviate_test.go
@@ -1,0 +1,33 @@
+/*                          _       _
+ *__      _____  __ ___   ___  __ _| |_ ___
+ *\ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+ * \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+ *  \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+ *
+ * Copyright © 2016 - 2018 Weaviate. All rights reserved.
+ * LICENSE: https://github.com/creativesoftwarefdn/weaviate/blob/develop/LICENSE.md
+ * AUTHOR: Bob van Luijt (bob@kub.design)
+ * See www.creativesoftwarefdn.org for details
+ * Contact: @CreativeSofwFdn / bob@kub.design
+ */
+
+package restapi
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestCreateErrorResponseObject(t *testing.T) {
+	testResults := createErrorResponseObject("error message 1", "error message 2")
+
+	// check which type is used
+	if typeName := reflect.TypeOf(testResults); typeName.Kind() == reflect.Ptr {
+		if typeName.Elem().Name() != "ErrorResponse" {
+			t.Error("Wrong struct used, should be ErrorResponse but is: ", typeName.Elem().Name())
+		}
+	} else {
+		t.Error("Wrong struct used, should be ErrorResponse but is: ", typeName.Name())
+	}
+
+}

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -1297,10 +1297,13 @@ func init() {
       "type": "object",
       "properties": {
         "error": {
-          "type": "object",
-          "properties": {
-            "message": {
-              "type": "string"
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "message": {
+                "type": "string"
+              }
             }
           }
         }
@@ -3218,10 +3221,13 @@ func init() {
       "type": "object",
       "properties": {
         "error": {
-          "type": "object",
-          "properties": {
-            "message": {
-              "type": "string"
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "message": {
+                "type": "string"
+              }
             }
           }
         }


### PR DESCRIPTION
#521 is implemented with variadic functions.

Usage:

```golang
createErrorResponseObject(message ...string)
```

Example:

```golang
createErrorResponseObject("Error 1", "Error 2", "etc")
```

Docs:

Added to the [contributors guide](https://github.com/creativesoftwarefdn/weaviate/commit/53611b051a771bcfc59a840f7b1a51c09ae656d2)