### PR TITLE
gh-530: Add flag to disable running the GraphQL tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,8 @@ go:
   - "1.11"
 env:
   - GO111MODULE=on
+  # Disable GraphQL tests
+  - GRAPHQL_TESTS=skip
 language: go
 install:  
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter

--- a/test/acceptance/graphql_schema_test.go
+++ b/test/acceptance/graphql_schema_test.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -23,6 +24,18 @@ import (
 
 const enableNetworkQueryComparison bool = false
 
+func init() {
+	skipGraphqlTest = (os.Getenv("GRAPHQL_TESTS") == "skip")
+}
+
+var skipGraphqlTest bool
+
+func maybeSkipGraphqlTest(t *testing.T) {
+	if skipGraphqlTest {
+		t.Skip("Skipping GraphQL tests")
+	}
+}
+
 /*
 Loop through all branches of the expected schema and compare each leaf to an
 actual schema retrieved from an introspection query on a local weaviate
@@ -30,6 +43,7 @@ actual schema retrieved from an introspection query on a local weaviate
 Note: Can't compare nested lists ([[][]]) properly, but that is out of scope for the current case
 */
 func TestCompareExpectedToActualSchemaWithIntrospection(t *testing.T) {
+	maybeSkipGraphqlTest(t)
 	t.Parallel()
 
 	// get expected schema


### PR DESCRIPTION
This will enable us to have green development branches again.

Closes gh-530.