### PR TITLE
gh-578: adding dev mode flag to fix build

### DIFF
--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -19,6 +19,8 @@ services:
     ports:
      - "8182:8182"
      - "8184:8184"
+    environment:
+     - DEV_MODE=true
   db:
     image: scylladb/scylla:2.0.1
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,6 +60,8 @@ services:
     ports:
      - "8182:8182"
      - "8184:8184"
+    environment:
+     - DEV_MODE=true
   db:
     image: scylladb/scylla:2.0.1
     ports:


### PR DESCRIPTION
When running via docker-compose, the janusgraph image just throws an error if the DB is not available. So it doesn't work, but won't retry.
However on K8s, it restarts until it is able to connect (the desired behavior).
This is a quick fix to solve this (and fix the broken build). Long term we need to see why this is behaving differently on each env.