### PR TITLE
gh-775: don't error if number fields not present in resolver

### DIFF
--- a/graphqlapi/common/json_number.go
+++ b/graphqlapi/common/json_number.go
@@ -26,7 +26,7 @@ func JSONNumberResolver(p graphql.ResolveParams) (interface{}, error) {
 
 	field, ok := sourceMap[p.Info.FieldName]
 	if !ok {
-		return nil, fmt.Errorf("sourcemap has no field '%s', got %#v", p.Info.FieldName, sourceMap)
+		return nil, nil
 	}
 
 	switch n := field.(type) {

--- a/graphqlapi/common/json_number_test.go
+++ b/graphqlapi/common/json_number_test.go
@@ -64,3 +64,17 @@ func resolveParams(input interface{}) graphql.ResolveParams {
 		Info: graphql.ResolveInfo{FieldName: "myField"},
 	}
 }
+
+func TestNumberFieldNotPresent(t *testing.T) {
+	// shouldn't return anything, but also not error. This can otherwise lead to
+	// odd behavior when no entries are present, yet we asked for int props and
+	// type, see https://github.com/creativesoftwarefdn/weaviate/issues/775
+	params := graphql.ResolveParams{
+		Source: map[string]interface{}{},
+		Info:   graphql.ResolveInfo{FieldName: "myField"},
+	}
+
+	result, err := JSONNumberResolver(params)
+	assert.Nil(t, err)
+	assert.Equal(t, nil, result)
+}

--- a/tools/dev/schema/things_schema.json
+++ b/tools/dev/schema/things_schema.json
@@ -235,6 +235,33 @@
                     "description": "number of seats available in the aircraft."
                 }
             ]
+        },
+        {
+            "class": "Car",
+            "description": "A specific car with make and model",
+            "properties": [
+                {
+                    "name": "model",
+                    "@dataType": [
+                        "string"
+                    ],
+                    "description": "name of the model"
+                },
+                {
+                    "name": "power",
+                    "@dataType": [
+                        "int"
+                    ],
+                    "description": "horsepower of the engine"
+                },
+                {
+                    "name": "weight",
+                    "@dataType": [
+                        "number"
+                    ],
+                    "description": "total weight of the car, including driver and a full gas tank"
+                }
+            ]
         }
     ]
 }


### PR DESCRIPTION
This addresses some of the concerns, but not all outlined in #775. It is nevertheless helpful because it will unblock @dljcollette with his work on the playground. However, we should thus keep #775 open until all issues are addressed.