### PR TITLE
gh-850: bugfix/small resources

### DIFF
--- a/docker-compose-spark.yml
+++ b/docker-compose-spark.yml
@@ -112,6 +112,8 @@ services:
     ports:
      - "9200:9200"
      - "9300:9300"
+    environment:
+     - ES_JAVA_OPTS=-Xms500m -Xmx500m
     volumes:
      - ./data/elasticsearch/data:/usr/share/elasticsearch/data
   etcd:

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -90,6 +90,8 @@ services:
     ports:
      - "9200:9200"
      - "9300:9300"
+    environment:
+     - ES_JAVA_OPTS=-Xms500m -Xmx500m
     volumes:
      - ./data/elasticsearch/data:/usr/share/elasticsearch/data
   genesis: # an actual genesis - not used in the weaviate tests, but used to test the genesis itself

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -112,6 +112,8 @@ services:
     ports:
      - "9200:9200"
      - "9300:9300"
+    environment:
+     - ES_JAVA_OPTS=-Xms500m -Xmx500m
     volumes:
      - ./data/elasticsearch/data:/usr/share/elasticsearch/data
   etcd:

--- a/docker-compose/runtime/docker-compose.yml
+++ b/docker-compose/runtime/docker-compose.yml
@@ -53,6 +53,8 @@ services:
     ports:
      - "9200:9200"
      - "9300:9300"
+    environment:
+     - ES_JAVA_OPTS=-Xms300m -Xmx300m
   etcd:
     image: gcr.io/etcd-development/etcd:v3.3.8
     ports:

--- a/docs/en/use/getting-started.md
+++ b/docs/en/use/getting-started.md
@@ -20,7 +20,12 @@
 
 ## Preparation
 
-If you want to learn more about the general concept of the Knowledge Graphs and Knowledge Networks you can read that [here](#). This getting started guide uses the dockerized versions of Weaviate. For more advanced usage or configuration, you can use the binaries and data connectors directly. This is covered in the [running Weaviate](running-weaviate.md#run-weaviate-stand-alone-with-docker) documentation.
+If you want to learn more about the general concept of the Knowledge Graphs and
+Knowledge Networks you can read that [here](#). This getting started guide uses
+the dockerized versions of Weaviate. For more advanced usage or configuration,
+you can use the binaries and data connectors directly. This is covered in the
+[running Weaviate](running-weaviate.md#run-weaviate-stand-alone-with-docker)
+documentation.
 
 Check you have Docker and Docker-compose installed:
 
@@ -29,7 +34,9 @@ $ docker --version
 $ docker-compose --version
 ```
 
-If you do not have Docker installed, you can read [here](https://docs.docker.com/install/) how to do this on a multitude of operating systems.
+If you do not have Docker installed, you can read
+[here](https://docs.docker.com/install/) how to do this on a multitude of
+operating systems.
 
 You are now ready to get started! If you run into issues, please use the:
 1. [Knowledge base of old issues](https://github.com/creativesoftwarefdn/weaviate/issues?utf8=%E2%9C%93&q=label%3Abug). Or,
@@ -38,15 +45,32 @@ You are now ready to get started! If you run into issues, please use the:
 
 ## Running Weaviate with Docker-compose
 
-All elements inside Weaviate are loosely coupled, meaning that you can use or [create](https://github.com/creativesoftwarefdn/weaviate/blob/develop/docs/en/contribute/custom-connectors.md) multiple database connectors. In this setup, we will be using the JanusGraph connector because it contains the most features for scaling Weaviate.
+All elements inside Weaviate are loosely coupled, meaning that you can use or
+[create](https://github.com/creativesoftwarefdn/weaviate/blob/develop/docs/en/contribute/custom-connectors.md)
+multiple database connectors. In this setup, we will be using the JanusGraph
+connector because it contains the most features for scaling Weaviate.
 
-Important to know;
-1. The whole setup uses a decent amount of memory. In case of issues, try increasing the memory limit that Docker has available. The setup runs from 2 CPU 12Gig memory. In case of issues check [this issue](https://github.com/creativesoftwarefdn/weaviate/issues/742).
-2. It takes some time to start up the whole infrastructure.
+#### Important information
+1. The docker-compose setup contains the entire weaviate stack, including a
+   Janusgraph/Elasticsearch connector. To run the entire stack you should have
+   at least **1 CPU and 3 GB of memory available**. If you are planning to import
+   large amounts of data, a larger setup is recommended.
+2. It takes some time to start up the whole infrastructure. During this time,
+   the backing databases will produce plenty of log output. We recommend to not
+   attach to the log-output of the entire setup, but only to those of weaviate.
+   Weaviate will will wait up to 2 minutes for the backing databases to come
+   up. This is indicated by logging `waiting to establish database connection,
+   this can take some time`. You will now that the entire stack is ready when
+   weaviate logs the bind address and port it is listenting on.
+3. The configuration values used in the docker-compose setup reflect a "Try it
+   out" or development setup. Production usage requires considerably more
+   resources. Do not use the docker-compose setup below in production. For
+   production setups, we recommend running the weaviate stack on Kubernetes.
 
 #### Starting Weaviate with Docker-compose
 
-You can find [here](running-weaviate.md#run-full-stack-with-docker-compose) how to run Weaviate with Docker-compose.
+You can find [here](running-weaviate.md#run-full-stack-with-docker-compose) how
+to run Weaviate with Docker-compose.
 
 Check if Weaviate is up and running by using the following curl command:
 

--- a/docs/en/use/getting-started.md
+++ b/docs/en/use/getting-started.md
@@ -52,7 +52,7 @@ connector because it contains the most features for scaling Weaviate.
 
 #### Important information
 1. The docker-compose setup contains the entire weaviate stack, including a
-   Janusgraph/Elasticsearch connector. To run the entire stack you should have
+   Janusgraph/Elasticsearch connector. To run this stack you should have
    at least **1 CPU and 3 GB of memory available**. If you are planning to import
    large amounts of data, a larger setup is recommended.
 2. It takes some time to start up the whole infrastructure. During this time,
@@ -60,7 +60,7 @@ connector because it contains the most features for scaling Weaviate.
    attach to the log-output of the entire setup, but only to those of weaviate.
    Weaviate will will wait up to 2 minutes for the backing databases to come
    up. This is indicated by logging `waiting to establish database connection,
-   this can take some time`. You will now that the entire stack is ready when
+   this can take some time`. You will know that the entire stack is ready when
    weaviate logs the bind address and port it is listenting on.
 3. The configuration values used in the docker-compose setup reflect a "Try it
    out" or development setup. Production usage requires considerably more

--- a/docs/en/use/running-weaviate.md
+++ b/docs/en/use/running-weaviate.md
@@ -62,10 +62,11 @@ Alternatively you can run docker-compose entirely detached with `docker-compose
 up -d` and poll `{bind_address}:{port}/weaviate/v1/meta` until you receive
 status `200 OK`.
 
+##### Additional Information
 
 _Note I: This Docker compose setup uses the `:latest` tag to ensure you always
 have the latest version. For production usage always use [a fixed version
-number](#running-a-specific-version)_
+tag](#running-a-specific-version)_
 
 _Note II: You can always enforce the latest `:latest` version by re-pulling
 `creativesoftwarefdn/weaviate:latest` and running `$docker-compose up -d --force-recreate`_

--- a/docs/en/use/running-weaviate.md
+++ b/docs/en/use/running-weaviate.md
@@ -20,7 +20,7 @@ development purposes.
 
 #### Important information
 1. The docker-compose setup contains the entire weaviate stack, including a
-   Janusgraph/Elasticsearch connector. To run the entire stack you should have
+   Janusgraph/Elasticsearch connector. To run this stack you should have
    at least **1 CPU and 3 GB of memory available**. If you are planning to
    import large amounts of data, a larger setup is recommended.
 2. It takes some time to start up the whole infrastructure. During this time,
@@ -28,7 +28,7 @@ development purposes.
    attach to the log-output of the entire setup, but only to those of weaviate
    as described here. Weaviate will will wait up to 2 minutes for the backing
    databases to come up. This is indicated by logging `waiting to establish
-   database connection, this can take some time`. You will now that the entire
+   database connection, this can take some time`. You will know that the entire
    stack is ready when weaviate logs the bind address and port it is listenting
    on.
 3. The configuration values used in the docker-compose setup reflect a "Try it
@@ -38,7 +38,7 @@ development purposes.
 
 #### Running the latest version
 
-#### Attaching to the log output of all containers
+##### Attaching to the log output of all containers
 
 Warning: The output is quite verbose, for an alternative see [attaching to only
 the log output of weaviate](#attaching-to-the-log-output-of-only-weaviate).
@@ -48,7 +48,7 @@ $ curl -s https://raw.githubusercontent.com/creativesoftwarefdn/weaviate/master/
 $ docker-compose up
 ```
 
-#### Attaching to the log output of only weaviate
+##### Attaching to the log output of only weaviate
 The log output of weaviate's backing databases can be quite verbose. We instead
 recommend to attach only to weaviate itself. In this case run `docker-compose
 up` like so:

--- a/docs/en/use/running-weaviate.md
+++ b/docs/en/use/running-weaviate.md
@@ -18,7 +18,7 @@ Cassandra) can be directly run with the Docker compose files available in this
 repo. This setup will also include the Weaviate Playground and ideal for
 development purposes.
 
-#### Important information
+### Important information
 1. The docker-compose setup contains the entire weaviate stack, including a
    Janusgraph/Elasticsearch connector. To run this stack you should have
    at least **1 CPU and 3 GB of memory available**. If you are planning to
@@ -36,9 +36,9 @@ development purposes.
    resources. Do not use the docker-compose setup below in production. For
    production setups, we recommend running the weaviate stack on Kubernetes.
 
-#### Running the latest version
+### Running the latest version
 
-##### Attaching to the log output of all containers
+#### Attaching to the log output of all containers
 
 Warning: The output is quite verbose, for an alternative see [attaching to only
 the log output of weaviate](#attaching-to-the-log-output-of-only-weaviate).
@@ -48,7 +48,7 @@ $ curl -s https://raw.githubusercontent.com/creativesoftwarefdn/weaviate/master/
 $ docker-compose up
 ```
 
-##### Attaching to the log output of only weaviate
+#### Attaching to the log output of only weaviate
 The log output of weaviate's backing databases can be quite verbose. We instead
 recommend to attach only to weaviate itself. In this case run `docker-compose
 up` like so:
@@ -62,7 +62,7 @@ Alternatively you can run docker-compose entirely detached with `docker-compose
 up -d` and poll `{bind_address}:{port}/weaviate/v1/meta` until you receive
 status `200 OK`.
 
-##### Additional Information
+#### Additional Information
 
 _Note I: This Docker compose setup uses the `:latest` tag to ensure you always
 have the latest version. For production usage always use [a fixed version
@@ -86,7 +86,7 @@ _Note II: You can always enforce the latest `:latest` version by re-pulling
   [here](https://github.com/creativesoftwarefdn/weaviate/tree/master/docker-compose/runtime)
   and run `docker-compose up -d`.
 
-#### Running a specific version
+### Running a specific version
 
 ```sh
 $ curl -s https://raw.githubusercontent.com/creativesoftwarefdn/weaviate/master/tools/download-docker-compose-deps.sh | bash
@@ -110,7 +110,7 @@ $ docker-compose up -d
 
 Weaviate can also be run stand-alone.
 
-#### Specific version
+### Specific version
 
 ```sh
 $ docker run creativesoftwarefdn/weaviate:$VERSION

--- a/docs/en/use/running-weaviate.md
+++ b/docs/en/use/running-weaviate.md
@@ -2,32 +2,88 @@
 
 > How to run Weaviate with Docker-compose, Docker or stand-alone.
 
-> Note for developers: the whole Weaviate stack needs quite some power, but it should run on a decent laptop for dev purposes.
+> Note for developers: the whole Weaviate stack needs quite some power, but it
+> should run on a decent laptop for dev purposes.
 
-This document describes how to run Weaviate for users. If you want to run a development version of Weaviate for contributors, click [here](../contribute/running-weaviate.md). Encountering issues? See the [overview of known issues](https://github.com/creativesoftwarefdn/weaviate/issues?utf8=%E2%9C%93&q=label%3Adocker+label%3Abug+) or ask [here](https://github.com/creativesoftwarefdn/weaviate#questions).
+This document describes how to run Weaviate for users. If you want to run a
+development version of Weaviate for contributors, click
+[here](../contribute/running-weaviate.md). Encountering issues? See the
+[overview of known issues](https://github.com/creativesoftwarefdn/weaviate/issues?utf8=%E2%9C%93&q=label%3Adocker+label%3Abug+)
+or ask [here](https://github.com/creativesoftwarefdn/weaviate#questions).
 
 ## Run full stack with Docker-compose
 
-A complete Weaviate stack based on Janusgraph (with Elasticsearch and Cassandra) can be directly run with the Docker compose files available in this repo. This setup will also include the Weaviate Playground and ideal for development purposes.
+A complete Weaviate stack based on Janusgraph (with Elasticsearch and
+Cassandra) can be directly run with the Docker compose files available in this
+repo. This setup will also include the Weaviate Playground and ideal for
+development purposes.
+
+#### Important information
+1. The docker-compose setup contains the entire weaviate stack, including a
+   Janusgraph/Elasticsearch connector. To run the entire stack you should have
+   at least **1 CPU and 3 GB of memory available**. If you are planning to
+   import large amounts of data, a larger setup is recommended.
+2. It takes some time to start up the whole infrastructure. During this time,
+   the backing databases will produce plenty of log output. We recommend to not
+   attach to the log-output of the entire setup, but only to those of weaviate
+   as described here. Weaviate will will wait up to 2 minutes for the backing
+   databases to come up. This is indicated by logging `waiting to establish
+   database connection, this can take some time`. You will now that the entire
+   stack is ready when weaviate logs the bind address and port it is listenting
+   on.
+3. The configuration values used in the docker-compose setup reflect a "Try it
+   out" or development setup. Production usage requires considerably more
+   resources. Do not use the docker-compose setup below in production. For
+   production setups, we recommend running the weaviate stack on Kubernetes.
 
 #### Running the latest version
+
+#### Attaching to the log output of all containers
+
+Warning: The output is quite verbose, for an alternative see [attaching to only
+the log output of weaviate](#attaching-to-the-log-output-of-only-weaviate).
 
 ```sh
 $ curl -s https://raw.githubusercontent.com/creativesoftwarefdn/weaviate/master/tools/download-docker-compose-deps.sh | bash
 $ docker-compose up
 ```
 
-_Note I: This Docker compose setup uses the `:latest` tag to ensure you always have the latest version. For production usage always use [a fixed version number](#running-a-specific-version)_
+#### Attaching to the log output of only weaviate
+The log output of weaviate's backing databases can be quite verbose. We instead
+recommend to attach only to weaviate itself. In this case run `docker-compose
+up` like so:
 
-_Note II: You can always enforce the latest `:latest` version by running `$ docker-compose up --force-recreate`_
+```sh
+$ curl -s https://raw.githubusercontent.com/creativesoftwarefdn/weaviate/master/tools/download-docker-compose-deps.sh | bash
+$ docker-compose up -d && docker-compose logs -f weaviate
+```
 
-- Releases can be found [here](https://github.com/creativesoftwarefdn/weaviate/releases).
-- Docker tags can be found [here](https://hub.docker.com/r/creativesoftwarefdn/weaviate/tags).
+Alternatively you can run docker-compose entirely detached with `docker-compose
+up -d` and poll `{bind_address}:{port}/weaviate/v1/meta` until you receive
+status `200 OK`.
+
+
+_Note I: This Docker compose setup uses the `:latest` tag to ensure you always
+have the latest version. For production usage always use [a fixed version
+number](#running-a-specific-version)_
+
+_Note II: You can always enforce the latest `:latest` version by re-pulling
+`creativesoftwarefdn/weaviate:latest` and running `$docker-compose up -d --force-recreate`_
+
+- Releases can be found
+  [here](https://github.com/creativesoftwarefdn/weaviate/releases).
+- Docker tags can be found
+  [here](https://hub.docker.com/r/creativesoftwarefdn/weaviate/tags).
 - Based on `tree/master` on Github
-- Runs with the latest open source Contextionary. More in-depth information about the contextionary can be found [here](../contribute/contextionary.md).
-- Weaviate becomes available as an HTTP service on port 8080 on `://{IP}/weaviate/v1/{COMMAND}`.
-- The Weaviate Playground becomes available as an HTTP service on port 80 on `://{IP}`.
-- If you want to manually download the files, download all files from [here](https://github.com/creativesoftwarefdn/weaviate/tree/master/docker-compose/runtime) and run `docker-compose up`.
+- Runs with the latest open source Contextionary. More in-depth information
+  about the contextionary can be found [here](../contribute/contextionary.md).
+- Weaviate becomes available as an HTTP service on port 8080 on
+  `http://{IP}/weaviate/v1/{RESOURCE}`.
+- The Weaviate Playground becomes available as an HTTP service on port 80 on
+  `http://{IP}`.
+- If you want to manually download the files, download all files from
+  [here](https://github.com/creativesoftwarefdn/weaviate/tree/master/docker-compose/runtime)
+  and run `docker-compose up -d`.
 
 #### Running a specific version
 
@@ -35,14 +91,19 @@ _Note II: You can always enforce the latest `:latest` version by running `$ dock
 $ curl -s https://raw.githubusercontent.com/creativesoftwarefdn/weaviate/master/tools/download-docker-compose-deps.sh | bash
 ```
 
-Open docker-compose.yml and replace `latest` in the image (`image: creativesoftwarefdn/weaviate:latest`) with the preferred version number. An overview can be found on [Dockerhub](https://hub.docker.com/r/creativesoftwarefdn/weaviate/tags).
+Open `docker-compose.yml` and replace `latest` in the image (`image:
+creativesoftwarefdn/weaviate:latest`) with the preferred version number. An
+overview can be found on
+[Dockerhub](https://hub.docker.com/r/creativesoftwarefdn/weaviate/tags).
 
 ```sh
-$ docker-compose up
+$ docker-compose up -d
 ```
 
-- Runs with the latest open source Contextionary. More in-depth information about the contextionary can be found [here](../contribute/contextionary.md).
-- Weaviate becomes available as HTTP service on port 8080 on `://{IP}/weaviate/v1/{COMMAND}`.
+- Runs with the latest open source Contextionary. More in-depth information
+  about the contextionary can be found [here](../contribute/contextionary.md).
+- Weaviate becomes available as HTTP service on port 8080 on
+  `://{IP}/weaviate/v1/{COMMAND}`.
 
 ## Run Weaviate stand-alone with Docker
 
@@ -54,13 +115,20 @@ Weaviate can also be run stand-alone.
 $ docker run creativesoftwarefdn/weaviate:$VERSION
 ```
 
-- Releases can be found [here](https://github.com/creativesoftwarefdn/weaviate/releases).
-- Runs with the latest open source Contextionary. More in-depth information about the contextionary can be found [here](../contribute/contextionary.md).
-- Weaviate becomes available as an HTTP service on port 8080 on `://{IP}/weaviate/v1/{COMMAND}`.
+- Releases can be found
+  [here](https://github.com/creativesoftwarefdn/weaviate/releases).
+- Runs with the latest open source Contextionary. More in-depth information
+  about the contextionary can be found [here](../contribute/contextionary.md).
+- Weaviate becomes available as an HTTP service on port 8080 on
+  `://{IP}/weaviate/v1/{COMMAND}`.
 
 ## Running with Custom Contextionary
 
-The contextionary files are built into the Docker image. To use a custom contextionary, you will need to build a custom Docker image. This can be done easily using the build argument `CONTEXTIONARY_LOC`. This argument can point either to a local folder or to a URL. This location must contain the following three files:
+The contextionary files are built into the Docker image. To use a custom
+contextionary, you will need to build a custom Docker image. This can be done
+easily using the build argument `CONTEXTIONARY_LOC`. This argument can point
+either to a local folder or to a URL. This location must contain the following
+three files:
 
 * contextionary.vocab
 * contextionary.knn
@@ -82,16 +150,19 @@ $ docker build -t my-weaviate-image --build-arg CONTEXTIONARY_LOC .
 
 ## Running with a custom server configuration
 
-If you want to run Weaviate with a specific configuration (for example over SSL or a different port) you can take the following steps.
+If you want to run Weaviate with a specific configuration (for example over SSL
+or a different port) you can take the following steps.
 
 ```sh
 # Clone the repo
 $ git clone https://github.com/creativesoftwarefdn/weaviate
-# Select the correct branch, 
+# Select the correct branch,
 ```
 
-- You can set the environment variable `SCHEME` to override the default (`http`) E.g. `SCHEME=https docker-compose up -d`
-- You can set the environment variables `HOST` and `PORT` to override the defaults. E.g. `HOST=0.0.0.0 PORT=1337 docker-compose up -d`	
+- You can set the environment variable `SCHEME` to override the default
+  (`http`) E.g. `SCHEME=https docker-compose up -d`
+- You can set the environment variables `HOST` and `PORT` to override the
+  defaults. E.g. `HOST=0.0.0.0 PORT=1337 docker-compose up -d`
 
 ## Running Kubernetes Setup
 


### PR DESCRIPTION
* closes #850 
* makes sure weaviate runs with 3GB of memory
* verified locally and with a `n1-standard-1` vm on GCE
* used the verification script manually on the machine mentioned above to import 200 vertices over 60 classes and make sure everything still works
* updated the docs
